### PR TITLE
Turn requirements links into https instead of ssh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,18 +6,18 @@ pytz==2014.7
 Pillow==2.6.1
 # jinja2 templates
 Jinja2==2.7.3
-git+ssh://git@github.com/concentricsky/jingo.git@v0.4
+git+https://github.com/concentricsky/jingo.git@v0.4
 # mysql database
 MySQL-python==1.2.5
 # Email support
 boto==2.33.0
 django-ses==0.6.0
 # CSky models
-git+ssh://git@github.com/concentricsky/django-cachemodel.git@v2.0.0
-git+ssh://git@github.com/concentricsky/django-basic-models.git@v2.1.0
+git+https://github.com/concentricsky/django-cachemodel.git@v2.0.0
+git+https://github.com/concentricsky/django-basic-models.git@v2.1.0
 # CSky Client Admin
-git+ssh://git@github.com/concentricsky/django-sky-ckeditor.git@v0.9.8
-git+ssh://git@github.com/concentricsky/django-client-admin.git@v1.1.1
+git+https://github.com/concentricsky/django-sky-ckeditor.git@v0.9.8
+git+https://github.com/concentricsky/django-client-admin.git@v1.1.1
 # Revision and deleted object recovery
 django-reversion==1.8.5
 # Memcached cache


### PR DESCRIPTION
Using ssh links causes problems when running pip install -r requirements.txt on a sandbox machine.