### PR TITLE
Ability to run Badgr-server using WSGI server

### DIFF
--- a/apps/wsgi.py
+++ b/apps/wsgi.py
@@ -1,0 +1,12 @@
+import sys
+import os
+
+APPS_DIR = os.path.abspath(os.path.dirname(__file__))
+if APPS_DIR not in sys.path:
+    sys.path.insert(0, APPS_DIR)
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mainsite.settings")
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+


### PR DESCRIPTION
Ability to run Badgr-server using WSGI server. For example using **gunicorn**:
```
$ source ../env/bin/activate
$ ../env/bin/gunicorn -b 0.0.0.0:8888 apps.wsgi:application --access-logfile=-
```