### PR TITLE
Azure Storage integration to store the badges and its assertions in blob storage.

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -136,7 +136,7 @@ class BadgeInstance(AbstractBadgeInstance):
             self.created_at = datetime.datetime.now()
             self.json['issuedOn'] = self.created_at.isoformat()
 
-           imageFile = default_storage.open(self.badgeclass.image)
+            imageFile = default_storage.open(self.badgeclass.image)
             self.image = bake(imageFile, json.dumps(self.json, indent=2))
 
             self.image.open()

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -136,7 +136,7 @@ class BadgeInstance(AbstractBadgeInstance):
             self.created_at = datetime.datetime.now()
             self.json['issuedOn'] = self.created_at.isoformat()
 
-            imageFile = default_storage.open(self.badgeclass.image.file.name)
+           imageFile = default_storage.open(self.badgeclass.image)
             self.image = bake(imageFile, json.dumps(self.json, indent=2))
 
             self.image.open()

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     # deprecated packages to remove in v1.2
     'composer',
     'credential_store',
+    'storages',
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/apps/mainsite/settings_local.py.example
+++ b/apps/mainsite/settings_local.py.example
@@ -13,6 +13,12 @@ DEBUG_MEDIA = DEBUG
 TIME_ZONE = 'America/Los_Angeles'
 LANGUAGE_CODE = 'en-us'
 
+#DEFAULT_FILE_STORAGE = 'storages.backends.azure_storage.AzureStorage'
+#AZURE_ACCOUNT_NAME = 'devbadgrstorage'
+#AZURE_ACCOUNT_KEY = 'WJqGOB4CzpysgQIv8rWdV764sHFKHPMwPS5M4OQF9KYldcKHOeHQy9UDf+xyadsawew+uR/adadeqasaeqw=='
+#MEDIA_URL = 'http://devbadgrstorage.blob.core.windows.net/'
+#AZURE_CONTAINER = 'mediafiles'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ MySQL-python==1.2.5
 boto==2.33.0
 django-boto==0.3.9
 django-ses==0.6.0
-django-storages==1.1.8
+django-storages==1.5.1
 python-resize-image==1.1.10
 # CSky models
 git+https://github.com/concentricsky/django-cachemodel.git@v2.1.3
@@ -70,11 +70,13 @@ python-json-logger==0.1.2
 
 # SSL Support
 cffi==1.2.1
-cryptography==1.0.2
+cryptography
 enum34==1.0.4
 idna==2.0
 ipaddress==1.0.14
 pyasn1==0.1.9
 pycparser==2.14
 six==1.9.0
-
+azure==1.0.3
+azure-storage==0.20.3
+django-azure-storage==0.20.1


### PR DESCRIPTION
This change is to enable the badgr application to store the badges and assertions in Azure blob storage.

1. Changes verified with file storage option (existing)
2. Changes verified with enabling the azure storage option.
3. Verified with Single click deployment - azure resource templates - https://github.com/satyarapelly/azure-quickstart-templates/tree/master/badgr-fullstack-ubuntu

