### PR TITLE
Reduce historical maximum recipient identifier length

### DIFF
--- a/apps/issuer/migrations/0037_auto_20171113_1015.py
+++ b/apps/issuer/migrations/0037_auto_20171113_1015.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='badgeinstance',
             name='recipient_identifier',
-            field=models.EmailField(db_index=True, max_length=1024),
+            field=models.EmailField(db_index=True, max_length=768),
         ),
     ]


### PR DESCRIPTION
@coffindragger One of our partners had difficulty running migrations from scratch on an RDS/MySQL environment. Updating this historical code is a possible way to get around this. I'll discuss this with you at 1pm.