### PR TITLE
Add more configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ If your badgr-ui is running on http://localhost:4000, use the following values:
 * UI connect success redirect: `http://localhost:4000/profile/`
 * Public pages redirect: `http://localhost:4000/public/`
 
+#### Sign-In Configuration
+
+* [Create an oAuth2 Provider Application](http://localhost:8000/staff/oauth2_provider/application/add/) with
+    * Client id: `public`
+    * Client type: Public
+    * allowed scopes: `rw:profile rw:issuer rw:backpack`
+    * Authorization grant type: Resource owner password-based
+    * Name: `localdev`
+    * Redirect uris: `http://localhost:4000`
+
 ### Additional configuration options
 Set these values in your settings_local.py file to configure the application to your specific needs. Required options are listed in bold.
 * *HELP_EMAIL* (Required)

--- a/README.md
+++ b/README.md
@@ -109,11 +109,6 @@ If your badgr-ui is running on http://localhost:4000, use the following values:
 * [Edit your super user](http://localhost:8000/staff/badgeuser/badgeuser/1/change/)
     * Add an email address, check "verified" and "primary"
 
-**Terms Configuration**
-
-* [Add an initial TermsVersion Object](http://localhost:8000/staff/badgeuser/termsversion/)
-    * This prevents the frontend from repeatedly asking the enduser to agree to terms
-
 * [Create an oAuth2 Provider Application](http://localhost:8000/staff/oauth2_provider/application/add/) with
     * Client id: `public`
     * Client type: Public

--- a/README.md
+++ b/README.md
@@ -92,7 +92,27 @@ If your badgr-ui is running on http://localhost:4000, use the following values:
 * UI connect success redirect: `http://localhost:4000/profile/`
 * Public pages redirect: `http://localhost:4000/public/`
 
-#### Sign-In Configuration
+#### Additional Configuration
+
+**Sign-In Configuration**
+
+* [Create an oAuth2 Provider Application](http://localhost:8000/staff/oauth2_provider/application/add/) with
+    * Client id: `public`
+    * Client type: Public
+    * allowed scopes: `rw:profile rw:issuer rw:backpack`
+    * Authorization grant type: Resource owner password-based
+    * Name: `localdev`
+    * Redirect uris: `http://localhost:4000`
+
+**User Configuration**
+
+* [Edit your super user](http://localhost:8000/staff/badgeuser/badgeuser/1/change/)
+    * Add an email address, check "verified" and "primary"
+
+**Terms Configuration**
+
+* [Add an initial TermsVersion Object](http://localhost:8000/staff/badgeuser/termsversion/)
+    * This prevents the frontend from repeatedly asking the enduser to agree to terms
 
 * [Create an oAuth2 Provider Application](http://localhost:8000/staff/oauth2_provider/application/add/) with
     * Client id: `public`


### PR DESCRIPTION
I had trouble getting `badgr-server` running locally. After looking at the `client_id` that was getting posted to the server and looking through the codebase I discovered I was missing an oauth2_provider application model. Adding instructions for creating one to the README.md to save future developers this pain.