### PR TITLE
Fix template and url warnings

### DIFF
--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -90,7 +90,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        # 'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
@@ -99,7 +98,6 @@ TEMPLATES = [
                 'django.template.context_processors.media',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
-                # 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
 
                 'mainsite.context_processors.extra_settings'
@@ -107,7 +105,6 @@ TEMPLATES = [
             'loaders': (
                 'django.template.loaders.app_directories.Loader',
                 'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
             ),
         },
         

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -90,7 +90,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
+        # 'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
@@ -104,11 +104,13 @@ TEMPLATES = [
 
                 'mainsite.context_processors.extra_settings'
             ],
+            'loaders': (
+                'django.template.loaders.app_directories.Loader',
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            ),
         },
-        'TEMPLATE_LOADERS': [
-            'django.template.loaders.filesystem.Loader',
-            'django.template.loaders.app_directories.Loader',
-        ],
+        
     },
 ]
 

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -105,13 +105,14 @@ TEMPLATES = [
                 'mainsite.context_processors.extra_settings'
             ],
         },
+        'TEMPLATE_LOADERS': [
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+        ],
     },
 ]
 
-TEMPLATE_LOADERS = [
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-]
+
 
 
 ##

--- a/apps/mainsite/settings_local.py.example
+++ b/apps/mainsite/settings_local.py.example
@@ -5,7 +5,6 @@ from settings import *
 from mainsite import TOP_DIR
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 DEBUG_ERRORS = DEBUG
 DEBUG_STATIC = DEBUG
 DEBUG_MEDIA = DEBUG

--- a/apps/mainsite/urls.py
+++ b/apps/mainsite/urls.py
@@ -77,7 +77,7 @@ urlpatterns = [
 
     # NOTE: pathway and recipient were written and deployed for beta testing at /v2/ before /v2/ was formalized
     # they do not conform to new /v2/ conventions,  they need to appear before /v2/ to not collide
-    url(r'^v2/issuers/(?P<issuer_slug>[^/]+)/pathways', include('pathway.api_urls'), kwargs={'version': 'v1'}),
+    url(r'^v2/issuers/(?P<issuer_slug>[^/]+)/pathways/', include('pathway.api_urls'), kwargs={'version': 'v1'}),
 
     # recipient was refactored to /v2/, but for now keep the old "v1" API registered at /v2/issuers/<issuer_slug/recipient-groups
     url(r'^v2/', include('recipient.v1_api_urls'), kwargs={'version': 'v1'}),

--- a/apps/pathway/api_urls.py
+++ b/apps/pathway/api_urls.py
@@ -5,9 +5,9 @@ from pathway.api import PathwayList, PathwayDetail, PathwayElementDetail, Pathwa
 
 urlpatterns = [
 
-    url(r'^/?$', PathwayList.as_view(), name='pathway_list'),
-    url(r'^/(?P<pathway_slug>[^/]+)$', PathwayDetail.as_view(), name='pathway_detail'),
-    url(r'^/(?P<pathway_slug>[^/]+)/elements$', PathwayElementList.as_view(), name='pathway_element_list'),
-    url(r'^/(?P<pathway_slug>[^/]+)/elements/(?P<element_slug>[^/]+)$', PathwayElementDetail.as_view(), name='pathway_element_detail'),
-    url(r'^/(?P<pathway_slug>[^/]+)/completion/(?P<element_slug>[^/]+)$', PathwayCompletionDetail.as_view(), name='pathway_completion_detail'),
+    url(r'^$', PathwayList.as_view(), name='pathway_list'),
+    url(r'^(?P<pathway_slug>[^/]+)$', PathwayDetail.as_view(), name='pathway_detail'),
+    url(r'^(?P<pathway_slug>[^/]+)/elements$', PathwayElementList.as_view(), name='pathway_element_list'),
+    url(r'^(?P<pathway_slug>[^/]+)/elements/(?P<element_slug>[^/]+)$', PathwayElementDetail.as_view(), name='pathway_element_detail'),
+    url(r'^(?P<pathway_slug>[^/]+)/completion/(?P<element_slug>[^/]+)$', PathwayCompletionDetail.as_view(), name='pathway_completion_detail'),
 ]


### PR DESCRIPTION
I am tired of seeing this wall of text every time I run the dev server:

```
?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values
of the following settings into your default TEMPLATES dict: TEMPLATE_LOADERS.
?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)$' [name='pathway_detail'] has a regex beginning with a '/'. Remove this slash as it is unne
cessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)/completion/(?P<element_slug>[^/]+)$' [name='pathway_completion_detail'] has a regex beginni
ng with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)/elements$' [name='pathway_element_list'] has a regex beginning with a '/'. Remove this slas
h as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)/elements/(?P<element_slug>[^/]+)$' [name='pathway_element_detail'] has a regex beginning wi
th a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
?: (urls.W002) Your URL pattern '^/?$' [name='pathway_list'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern
 is targeted in an include(), ensure the include() pattern has a trailing '/'.
```