### PR TITLE
[WIP] Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,13 @@ ADD requirements.txt .
 RUN pip install -r requirements.txt
 ENV PATH="$PATH:/badgr/.local/bin"
 
+CMD ./manage.py migrate && ./manage.py runserver
 ADD . .
 
-RUN chown -R badgr /badgr
-USER badgr
+#RUN chown -R badgr /badgr
+RUN cp docker/settings_local.py apps/mainsite/settings_local.py
 
-RUN cp apps/mainsite/settings_local.py.docker apps/mainsite/settings_local.py
+#USER badgr
 
-ENTRYPOINT docker/entrypoint.sh
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:2.7
+
+# add a user for the app on alpine
+#     https://github.com/gliderlabs/docker-alpine/issues/38#issuecomment-377520103
+# Packages according to README.md:
+# - https://www.itzgeek.com/how-tos/linux/debian/how-to-install-memcached-on-debian-9.html
+# - https://www.cairographics.org/download/
+RUN mkdir /badgr && \
+#    adduser -D -h /badgr badgr && \ # alpine
+    useradd -m -d /badgr badgr && \
+    chown -R badgr /badgr && \
+    apt-get update && \
+    apt-get -y install libcairo2-dev mysql-client
+
+# TODO: 
+# - https://docs.docker.com/samples/library/rabbitmq/
+# - https://docs.docker.com/samples/library/memcached/
+
+WORKDIR /badgr
+
+ADD requirements.txt .
+RUN pip install --user -r requirements.txt
+ENV PATH="$PATH:/badgr/.local/bin"
+
+ADD . .
+
+RUN chown -R badgr /badgr
+USER badgr
+
+RUN cp apps/mainsite/settings_local.py.docker apps/mainsite/settings_local.py
+
+ENTRYPOINT docker/entrypoint.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir /badgr && \
 WORKDIR /badgr
 
 ADD requirements.txt .
-RUN pip install --user -r requirements.txt
+RUN pip install -r requirements.txt
 ENV PATH="$PATH:/badgr/.local/bin"
 
 ADD . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ ADD requirements.txt .
 RUN pip install -r requirements.txt
 ENV PATH="$PATH:/badgr/.local/bin"
 
-CMD ./manage.py migrate && ./manage.py runserver
+ENTRYPOINT ["docker/entrypoint.sh"]
+CMD ["migrate", "runserver"]
 ADD . .
 
 #RUN chown -R badgr /badgr

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Create the container:
 ```shell
 docker build -t badgr .
 ```
+
+Debug image with sh:
+
+```shell
+docker build -t badgr . && docker run -i --rm --entrypoint /bin/sh badgr
+```
   
 ## Docker-Compose
 
@@ -151,6 +157,6 @@ Run the containers.
 ```shell
 docker network create code_backend
 docker network create code_frontend
-docker-compose create --force-recreate && docker-compose start
+_docker-compose create && docker-compose start
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,3 +135,22 @@ Set these values in your settings_local.py file to configure the application to 
   - Key used for symmetrical encryption of pagination cursors.  If not defined, encryption is disabled.  Must be 32 byte, base64-encoded random string.  For example: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key())"
 * AUTHCODE_SECRET_KEY must be 32 url-safe base64-encoded bytes:
   - Key used for symmetrical encryption of pagination cursors.  If not defined, encryption is disabled.  Must be 32 byte, base64-encoded random string as above.
+  
+## Docker
+
+Create the container:
+
+```shell
+docker build -t badgr .
+```
+  
+## Docker-Compose
+
+Run the containers.
+
+```shell
+docker network create code_backend
+docker network create code_frontend
+docker-compose create --force-recreate && docker-compose start
+```
+

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ docker build -t badgr .
 Debug image with sh:
 
 ```shell
-docker build -t badgr . && docker run -i --rm --entrypoint /bin/sh badgr
+docker run -i --rm --entrypoint /bin/sh badgr
 ```
   
 ## Docker-Compose
@@ -157,6 +157,15 @@ Run the containers.
 ```shell
 docker network create code_backend
 docker network create code_frontend
-_docker-compose create && docker-compose start
+docker-compose create && docker-compose up
 ```
 
+It will take some time for the migrations to run though and the frontend to
+build.
+Once the website http://localhost:8000/staff appears, you can run the following
+command to create an admin account for you. You may need to replace
+`code_badgr_1` with the container name of the badgr service.
+
+```shell
+docker exec -it code_badgr_1 ./manage.py createsuperuser
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     badgr:
         image: badgr
         build: .
-#        command: ./manage.py migrate && ./manage.py runserver
+#        command: migrate runserver
         links:
         - "mysql:mysql"
         - "ui:ui"
@@ -24,16 +24,18 @@ services:
 #        - "DEBUG_MEDIA=true"
 #        - "TIME_ZONE=America/Los_Angeles"
 #        - "LANGUAGE_CODE=en-us"
-        - "DATABASES.default.ENGINE=django.db.backends.mysql"
-        - "DATABASES.default.NAME=badgr"
-        - "DATABASES.default.USER=root"
-        - "DATABASES.default.PASSWORD=password" # same as in mysql.environment
-        - "DATABASES.default.HOST=mysql"
-#        - "DATABASES.default.PORT="
-#        - "CACHES.default.BACKEND=django.core.cache.backends.locmem.LocMemCache"
-#        - "CACHES.default.LOCATION="
-#        - "CACHES.default.TIMEOUT=300"
-#        - "CACHES.default.VERSION=1"
+        - "DATABASES_default_ENGINE=django.db.backends.mysql"
+        - "DATABASES_default_NAME=badgr"
+        - "DATABASES_default_USER=root"
+        - "DATABASES_default_PASSWORD=password" # same as in mysql.environment
+        - "DATABASES_default_HOST=mysql"
+        - "DATABASES_default_PORT=3306"
+## create the database when the server starts if it is not there, yet.
+        - "CREATE_DB_IF_NOT_EXISTS=yes"
+#        - "CACHES_default_BACKEND=django.core.cache.backends.locmem.LocMemCache"
+#        - "CACHES_default_LOCATION="
+#        - "CACHES_default_TIMEOUT=300"
+#        - "CACHES_default_VERSION=1"
 ## celery
 #        - "BROKER_URL=amqp://localhost:5672/"
 #        - "CELERY_RESULT_BACKEND=djcelery.backends.cache:CacheBackend"
@@ -64,6 +66,8 @@ services:
         image: mariadb
         environment:
         - "MYSQL_ROOT_PASSWORD=password"
+        ports:
+        - "3306:3306"
         networks:
         - backend
 #    volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     badgr:
         image: badgr
         build: .
-        command: migrate runserver
+#        command: ./manage.py migrate && ./manage.py runserver
         links:
-        - "postgresql:postgresql"
+        - "mysql:mysql"
         - "ui:ui"
         ports:
         - "8000:8000"
@@ -13,7 +13,7 @@ services:
         - backend
         - frontend
         depends_on:
-        - postgresql
+        - mysql
         - ui
         environment:
 ## uncomment the following lines to configure the service
@@ -24,11 +24,11 @@ services:
 #        - "DEBUG_MEDIA=true"
 #        - "TIME_ZONE=America/Los_Angeles"
 #        - "LANGUAGE_CODE=en-us"
-        - "DATABASES.default.ENGINE=django.db.backends.postgresql"
-        - "DATABASES.default.NAME=badgr" # same as in postgresql.environment.DB_NAME
-        - "DATABASES.default.USER=badgr" # same as in postgresql.environment.DB_USER
-        - "DATABASES.default.PASSWORD=password" # same as in postgresql.environment.DB_PASS
-        - "DATABASES.default.HOST=postgresql"
+        - "DATABASES.default.ENGINE=django.db.backends.mysql"
+        - "DATABASES.default.NAME=badgr"
+        - "DATABASES.default.USER=root"
+        - "DATABASES.default.PASSWORD=password" # same as in mysql.environment
+        - "DATABASES.default.HOST=mysql"
 #        - "DATABASES.default.PORT="
 #        - "CACHES.default.BACKEND=django.core.cache.backends.locmem.LocMemCache"
 #        - "CACHES.default.LOCATION="
@@ -60,20 +60,28 @@ services:
 #        - "OPEN_FOR_SIGNUP="
 #        - "PAGINATION_SECRET_KEY="
 #        - "AUTHCODE_SECRET_KEY="
-    postgresql:
-        restart: always
-        image: sameersbn/postgresql:latest
+    mysql:
+        image: mariadb
+        environment:
+        - "MYSQL_ROOT_PASSWORD=password"
+        networks:
+        - backend
+#    volumes:
+#    - "PATH/TO/VOLUME:/var/lib/mysql"
+#    postgresql:
+#        restart: always
+#        image: sameersbn/postgresql:latest
 ## uncomment this to persist the data at different locations
 #        volumes:
 #        - "PATH/TO/VOLUME:/var/lib/postgresql:Z"
 #        - "PATH/TO/VOLUME:/var/log/postgresql:Z"
-        networks:
-        - backend
-        environment:
-        - DB_USER=badgr
-        - DB_PASS=password
-        - DB_NAME=gitlabhq_production
-        - DB_EXTENSION=pg_trgm
+#        networks:
+#        - backend
+#        environment:
+#        - DB_USER=badgr
+#        - DB_PASS=password
+#        - DB_NAME=gitlabhq_production
+#        - DB_EXTENSION=pg_trgm
     ui:
         image: badgr-ui
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     badgr:
         image: badgr
         build: .
-#        command: migrate runserver
+        command: ["migrate", "runserver 0.0.0.0:8000"]
         links:
         - "mysql:mysql"
         - "ui:ui"
@@ -17,7 +17,7 @@ services:
         - ui
         environment:
 ## uncomment the following lines to configure the service
-#        - "DEBUG=true"
+        - "DEBUG=true"
 #        - "TEMPLATE_DEBUG=true"
 #        - "DEBUG_ERRORS=true"
 #        - "DEBUG_STATIC=true"
@@ -54,7 +54,8 @@ services:
 #        - "EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend"
 #        - "DEFAULT_FROM_EMAIL="
 ## list of hosts seperated by spaces
-        - "ALLOWED_HOSTS=localhost:8000"
+## see https://docs.djangoproject.com/en/2.1/ref/settings/#allowed-hosts
+        - "ALLOWED_HOSTS=*"
 ## additional options as defined in the README
 #        - "HELP_EMAIL="
 #        - "GOOGLE_ANALYTICS_ID="

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,87 @@
+version: '2'
+services:
+    badgr:
+        image: badgr
+        build: .
+        command: migrate runserver
+        links:
+        - "postgresql:postgresql"
+        - "ui:ui"
+        ports:
+        - "8000:8000"
+        networks:
+        - backend
+        - frontend
+        depends_on:
+        - postgresql
+        - ui
+        environment:
+## uncomment the following lines to configure the service
+#        - "DEBUG=true"
+#        - "TEMPLATE_DEBUG=true"
+#        - "DEBUG_ERRORS=true"
+#        - "DEBUG_STATIC=true"
+#        - "DEBUG_MEDIA=true"
+#        - "TIME_ZONE=America/Los_Angeles"
+#        - "LANGUAGE_CODE=en-us"
+        - "DATABASES.default.ENGINE=django.db.backends.postgresql"
+        - "DATABASES.default.NAME=badgr" # same as in postgresql.environment.DB_NAME
+        - "DATABASES.default.USER=badgr" # same as in postgresql.environment.DB_USER
+        - "DATABASES.default.PASSWORD=password" # same as in postgresql.environment.DB_PASS
+        - "DATABASES.default.HOST=postgresql"
+#        - "DATABASES.default.PORT="
+#        - "CACHES.default.BACKEND=django.core.cache.backends.locmem.LocMemCache"
+#        - "CACHES.default.LOCATION="
+#        - "CACHES.default.TIMEOUT=300"
+#        - "CACHES.default.VERSION=1"
+## celery
+#        - "BROKER_URL=amqp://localhost:5672/"
+#        - "CELERY_RESULT_BACKEND=djcelery.backends.cache:CacheBackend"
+#        - "CELERY_TASK_SERIALIZER=json"
+#        - "CELERY_RESULTS_SERIALIZER=json"
+#        - "CELERY_ACCEPT_CONTENT=json"
+## See README
+#        - "CELERY_ALWAYS_EAGER=true"
+        - "HTTP_ORIGIN=http://localhost:8000"
+## Optionally restrict issuer creation to accounts that have the 'issuer.add_issuer' permission
+## See README
+#        - "BADGR_APPROVED_ISSUERS_ONLY=true"
+## If you have an informational front page outside the Django site that can link back to '/login', specify it here 
+#        - "ROOT_INFO_REDIRECT=/login"
+#        - "LOGS_DIR="
+#        - "EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend"
+#        - "DEFAULT_FROM_EMAIL="
+## list of hosts seperated by spaces
+        - "ALLOWED_HOSTS=localhost:8000"
+## additional options as defined in the README
+#        - "HELP_EMAIL="
+#        - "GOOGLE_ANALYTICS_ID="
+#        - "PINGDOM_MONITORING_ID="
+#        - "OPEN_FOR_SIGNUP="
+#        - "PAGINATION_SECRET_KEY="
+#        - "AUTHCODE_SECRET_KEY="
+    postgresql:
+        restart: always
+        image: sameersbn/postgresql:latest
+## uncomment this to persist the data at different locations
+#        volumes:
+#        - "PATH/TO/VOLUME:/var/lib/postgresql:Z"
+#        - "PATH/TO/VOLUME:/var/log/postgresql:Z"
+        networks:
+        - backend
+        environment:
+        - DB_USER=badgr
+        - DB_PASS=password
+        - DB_NAME=gitlabhq_production
+        - DB_EXTENSION=pg_trgm
+    ui:
+        image: badgr-ui
+        ports:
+        - "4000:4000"
+        networks:
+        - frontend
+networks:
+    frontend:
+    backend:
+  
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,9 @@ services:
         - "4000:4000"
         networks:
         - frontend
+        environment:
+        - "DOMAIN=localhost:8000" # like one of badgr.environment.ALLOWED_HOSTS
 networks:
     frontend:
     backend:
-  
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for arg in "$@"; do
+    ./manage.py "$arg"
+done
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
-echo "$@"
-for arg in "$@"; do
-    echo " ------------- ./manage.py $arg ------------- "
-    ./manage.py "$arg"
-done
+
+if [ "$DATABASES_default_ENGINE" == "django.db.backends.mysql" ] && [ -n "$CREATE_DB_IF_NOT_EXISTS" ]; then
+  echo "mysql chosen, setting up database"
+  if mysql -u $DATABASES_default_USER -p$DATABASES_default_PASSWORD -h $DATABASES_default_HOST -P $DATABASES_default_PORT -D $DATABASES_default_NAME; then
+    echo "database $DATABASES_default_NAME exists."
+  else
+    echo "CREATE DATABASE $DATABASES_default_NAME; exit;" | mysql -u $DATABASES_default_USER -p$DATABASES_default_PASSWORD -h $DATABASES_default_HOST -P $DATABASES_default_PORT  
+  fi
+fi
+
+if [ -n "$1" ]; then
+  for command in "$@"; do
+    echo " -------- $command -------- "
+    ./manage.py "$command"
+  done
+else
+  1>&2 echo "no arguments given: $@"
+  exit 1
+fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
+set -e
+echo "$@"
 for arg in "$@"; do
+    echo " ------------- ./manage.py $arg ------------- "
     ./manage.py "$arg"
 done
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,11 +2,26 @@
 
 set -e
 
+if [ -n "$DATABASES_default_HOST" ] && [ -n "$DATABASES_default_PORT" ]; then
+  for i in `seq 1 60`; do
+    echo -n .
+    if python -c "import socket; socket.socket().connect(('$DATABASES_default_HOST', $DATABASES_default_PORT))" 2> /dev/null; then
+      echo
+      echo "INFO: Database up at $DATABASES_default_HOST:$DATABASES_default_PORT."
+      break
+    fi
+    sleep 1
+  done
+else
+  echo "INFO: set the environment variables DATABASES_default_HOST and DATABASES_default_PORT to wait for the database to come up."
+fi
+
 if [ "$DATABASES_default_ENGINE" == "django.db.backends.mysql" ] && [ -n "$CREATE_DB_IF_NOT_EXISTS" ]; then
-  echo "mysql chosen, setting up database"
+  echo "INFO: mysql chosen"
   if mysql -u $DATABASES_default_USER -p$DATABASES_default_PASSWORD -h $DATABASES_default_HOST -P $DATABASES_default_PORT -D $DATABASES_default_NAME; then
-    echo "database $DATABASES_default_NAME exists."
+    echo "INFO: database \"$DATABASES_default_NAME\" exists."
   else
+    echo "INFO: setting up database \"$DATABASES_default_NAME\"."
     echo "CREATE DATABASE $DATABASES_default_NAME; exit;" | mysql -u $DATABASES_default_USER -p$DATABASES_default_PASSWORD -h $DATABASES_default_HOST -P $DATABASES_default_PORT  
   fi
 fi
@@ -14,10 +29,10 @@ fi
 if [ -n "$1" ]; then
   for command in "$@"; do
     echo " -------- $command -------- "
-    ./manage.py "$command"
+    ./manage.py $command
   done
 else
-  1>&2 echo "no arguments given: $@"
+  1>&2 echo "ERROR: no arguments given: $@"
   exit 1
 fi
 


### PR DESCRIPTION
I would like to run these services inside a docker container. This is what I tried.

Currently, I wonder why the migrations are running without a connection to the database server.

I think, I better share this in case people are looking for it.

Either I get:

```
badgr_1  | django.db.utils.OperationalError: (1049, "Unknown database 'badgr'")
```

or it hangs after the migrations are done:

```
badgr_1  |   Applying socialaccount.0003_extra_data_default_dict... OK
badgr_1  | System check identified some issues:
badgr_1  | 
badgr_1  | WARNINGS:
badgr_1  | ?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default TEMPLATES dict: TEMPLATE_DEBUG, TEMPLATE_LOADERS.
badgr_1  | ?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)$' [name='pathway_detail'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
badgr_1  | ?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)/completion/(?P<element_slug>[^/]+)$' [name='pathway_completion_detail'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
badgr_1  | ?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)/elements$' [name='pathway_element_list'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
badgr_1  | ?: (urls.W002) Your URL pattern '^/(?P<pathway_slug>[^/]+)/elements/(?P<element_slug>[^/]+)$' [name='pathway_element_detail'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
badgr_1  | ?: (urls.W002) Your URL pattern '^/?$' [name='pathway_list'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
badgr_1  | 
badgr_1  | System check identified 6 issues (0 silenced).

```

