### PR TITLE
Track source and signup params

### DIFF
--- a/apps/badgeuser/api.py
+++ b/apps/badgeuser/api.py
@@ -7,7 +7,7 @@ import urlparse
 from allauth.account.adapter import get_adapter
 from allauth.account.models import EmailConfirmationHMAC
 from allauth.account.utils import user_pk_to_url_str, url_str_to_user_pk
-from apispec_drf.decorators import (apispec_get_operation, apispec_put_operation, apispec_operation,
+from apispec_drf.decorators import (apispec_get_operation, apispec_put_operation, apispec_post_operation, apispec_operation,
     apispec_delete_operation, apispec_list_operation,)
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -57,6 +57,11 @@ class BadgeUserDetail(BaseEntityDetailView):
         "put": ["rw:profile"],
     }
 
+    @apispec_post_operation('BadgeUser',
+        summary="Post a single BadgeUser profile",
+        description="Make an account",
+        tags=['BadgeUsers']
+    )
     def post(self, request, **kwargs):
         """
         Signup for a new account

--- a/apps/badgeuser/tests.py
+++ b/apps/badgeuser/tests.py
@@ -81,6 +81,7 @@ class UserCreateTests(BadgrTestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("signup=true", mail.outbox[0].body)
     
     def test_create_user_from_mozilla(self):
         user_data = {

--- a/apps/badgrsocialauth/views.py
+++ b/apps/badgrsocialauth/views.py
@@ -34,6 +34,8 @@ class BadgrSocialLogin(RedirectView):
             set_session_badgr_app(self.request, badgr_app)
         else:
             raise ValidationError('Unable to save BadgrApp in session')
+        
+        self.request.session['source'] = self.request.query_params.get('source', None)
 
         try:
             redirect_url = reverse('{}_login'.format(self.request.GET.get('provider')))


### PR DESCRIPTION
I intentionally left a few guiding print statements in to keep track of the flow.

- [x] Include `?source=mozilla` in confirmation url if it was included in create account POST body
- [x] Conditionally include `?signup=true` in confirmation url if user is brand new
- [x] Get `source` from session during oAuth flow, add to confirmation url (new user) and redirect url (existing user)
- [x] Remove `print()`, squash force push, request review