### PR TITLE
Support allowDuplicateAwards parameter on badge awards.

### DIFF
--- a/apps/entity/serializers.py
+++ b/apps/entity/serializers.py
@@ -149,6 +149,13 @@ class V2ErrorSerializer(BaseSerializerV2):
         super(V2ErrorSerializer, self).__init__(*args, **kwargs)
 
     def to_representation(self, instance):
+        try:
+            self.validation_errors = self.validation_errors + self.field_errors.pop('non_field_errors', [])
+        except TypeError:
+            # In the case where field_errors is a list of dicts, we keep non_field_errors grouped with other field
+            # errors for that object
+            pass
+
         return BaseSerializerV2.response_envelope(result=[],
                                                   success=self.success,
                                                   description=self.description,


### PR DESCRIPTION
Optionally, an API client can add an `allowDuplicateAwards` parameter (`allow_duplicate_awards` in the legacy v1 API). This defaults to true if not included, but if set to false manually it will run a check prior to award that will skip with a validation error if the user has requested that an award be made to someone duplicate.

In the future, we'll include an issuer-level default for this, and maybe varying degrees of seriousness, so an issuer could not allow this to be overridden at the single award request level, for instance.