### PR TITLE
Blacklist Feature

### DIFF
--- a/apps/badgeuser/managers.py
+++ b/apps/badgeuser/managers.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 
 from badgeuser.authcode import encrypt_authcode
 from mainsite.models import BadgrApp, OriginSetting
+from badgrsocialauth.utils import set_url_query_params
 
 
 class BadgeUserManager(UserManager):
@@ -48,13 +49,13 @@ class BadgeUserManager(UserManager):
                 # We shouldn't set any of the user attributes at this time until confirmation
                 user = existing_email.user
                 self.send_account_confirmation(
-                  email=email,
-                  first_name=first_name,
-                  last_name=last_name,
-                  badgrapp_id=badgrapp.id,
-                  marketing_opt_in=marketing_opt_in,
-                  plaintext_password=plaintext_password,
-                  source=source
+                    email=email,
+                    first_name=first_name,
+                    last_name=last_name,
+                    badgrapp_id=badgrapp.id,
+                    marketing_opt_in=marketing_opt_in,
+                    plaintext_password=plaintext_password,
+                    source=source
                 )
                 return self.model(email=email)
             elif existing_email.verified:

--- a/apps/badgrlog/events/blacklist.py
+++ b/apps/badgrlog/events/blacklist.py
@@ -1,4 +1,5 @@
 from .base import BaseBadgrEvent
+from mainsite.blacklist import generate_hash
 
 
 class BlacklistEarnerNotNotifiedEvent(BaseBadgrEvent):
@@ -14,12 +15,14 @@ class BlacklistEarnerNotNotifiedEvent(BaseBadgrEvent):
 
 class BlacklistAssertionNotCreatedEvent(BaseBadgrEvent):
     def __init__(self, badge_instance):
-        self.badge_instance = badge_instance
+        self.recipient_id_hash = \
+            generate_hash(badge_instance.recipient_type, badge_instance.recipient_identifier)
+        self.entity_id = badge_instance.badgeclass.entity_id
 
     def to_representation(self):
         return {
-            'recipient_identifier': self.badge_instance.recipient_identifier,
-            'badge_instance': self.badge_instance.json,
+            'recipient_id_hash': self.recipient_id_hash,
+            'badgeclass_entity_id': self.entity_id,
         }
 
 

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -786,12 +786,9 @@ class BadgeInstance(BaseAuditedModel,
 
     def save(self, *args, **kwargs):
         if self.pk is None:
-            is_in_blacklist = \
-                blacklist.api_query_is_in_blacklist(self.recipient_identifier)
-
-            if is_in_blacklist == True:
-                badge_instance = self
-                logger.event(badgrlog.BlacklistAssertionNotCreatedEvent(badge_instance))
+            # First check if recipient is in the blacklist
+            if blacklist.api_query_is_in_blacklist(self.recipient_type, self.recipient_identifier):
+                logger.event(badgrlog.BlacklistAssertionNotCreatedEvent(self))
                 return
 
             self.salt = uuid.uuid4().hex

--- a/apps/mainsite/blacklist.py
+++ b/apps/mainsite/blacklist.py
@@ -60,9 +60,10 @@ def api_query_is_in_blacklist(id_type, recipient_id):
             return True
         else:
             return False
-    # The assertion should not be created
-    # Raise blacklist not configured: blacklist_api_key blacklist_query_endpoint
-    raise Exception("")
+
+    if not response:
+        raise Exception("Blacklist failed to respond")
+
     return None
 
 

--- a/apps/mainsite/blacklist.py
+++ b/apps/mainsite/blacklist.py
@@ -15,7 +15,7 @@ blacklist_query_endpoint = getattr(settings, 'BADGR_BLACKLIST_QUERY_ENDPOINT', N
 
 def api_submit_email(id_type, email):
     if blacklist_api_key and blacklist_query_endpoint:
-        email_hash = generate_hash(id_type, email)
+        email_hash = _generate_hash(id_type, email)
 
         try:
             response = requests.post(
@@ -34,7 +34,7 @@ def api_submit_email(id_type, email):
 
 def api_query_email(id_type, email):
     if blacklist_api_key and blacklist_query_endpoint:
-        email_hash = generate_hash(id_type, email)
+        email_hash = _generate_hash(id_type, email)
 
         request_query = "{endpoint}?id={email_hash}".format(
             endpoint=blacklist_query_endpoint,
@@ -67,7 +67,7 @@ def api_query_is_in_blacklist(id_type, email):
     return None
 
 
-def generate_hash(id_type, id_value):
+def _generate_hash(id_type, id_value):
     return "${id_type}$sha256${hash}".format(id_type=id_type,
                                              hash=sha256(id_value).hexdigest())
 
@@ -80,7 +80,7 @@ def generate_email_signature(email):
         int((expiration - datetime(1970, 1, 1)).total_seconds())
 
     email_encoded = base64.b64encode(email)
-    email_hash = generate_hash('email', email)
+    email_hash = _generate_hash('email', email)
     timestamp_hash = hmac.new(
         secret_key, email_encoded + str(expiration_timestamp), sha1)
 

--- a/apps/mainsite/blacklist.py
+++ b/apps/mainsite/blacklist.py
@@ -1,25 +1,21 @@
-import base64
-from datetime import datetime, timedelta
-from hashlib import sha1, sha256
-import hmac
+from hashlib import sha256
 
 import requests
 from requests.exceptions import ConnectionError
 
-from django.core.urlresolvers import reverse
 from django.conf import settings
 
 blacklist_api_key = getattr(settings, 'BADGR_BLACKLIST_API_KEY', None)
 blacklist_query_endpoint = getattr(settings, 'BADGR_BLACKLIST_QUERY_ENDPOINT', None)
 
 
-def api_submit_email(id_type, email):
+def api_submit_recipient_id(id_type, recipient_id):
     if blacklist_api_key and blacklist_query_endpoint:
-        email_hash = _generate_hash(id_type, email)
+        recipient_id_hash = _generate_hash(id_type, recipient_id)
 
         try:
             response = requests.post(
-                blacklist_query_endpoint, json={"id": email_hash}, headers={
+                blacklist_query_endpoint, json={"id": recipient_id_hash}, headers={
                     "Authorization": "BEARER {api_key}".format(
                         api_key=blacklist_api_key
                     ),
@@ -32,13 +28,13 @@ def api_submit_email(id_type, email):
         return None
 
 
-def api_query_email(id_type, email):
+def api_query_recipient_id(id_type, recipient_id):
     if blacklist_api_key and blacklist_query_endpoint:
-        email_hash = _generate_hash(id_type, email)
+        recipient_id_hash = _generate_hash(id_type, recipient_id)
 
-        request_query = "{endpoint}?id={email_hash}".format(
+        request_query = "{endpoint}?id={recipient_id_hash}".format(
             endpoint=blacklist_query_endpoint,
-            email_hash=email_hash)
+            recipient_id_hash=recipient_id_hash)
 
         try:
             response = requests.get(request_query, headers={
@@ -54,8 +50,8 @@ def api_query_email(id_type, email):
         return None
 
 
-def api_query_is_in_blacklist(id_type, email):
-    response = api_query_email(id_type, email)
+def api_query_is_in_blacklist(id_type, recipient_id):
+    response = api_query_recipient_id(id_type, recipient_id)
 
     if response and response.status_code == 200:
         query = response.json()
@@ -70,37 +66,3 @@ def api_query_is_in_blacklist(id_type, email):
 def _generate_hash(id_type, id_value):
     return "${id_type}$sha256${hash}".format(id_type=id_type,
                                              hash=sha256(id_value).hexdigest())
-
-
-def generate_email_signature(email):
-    secret_key = settings.UNSUBSCRIBE_SECRET_KEY
-
-    expiration = datetime.utcnow() + timedelta(days=7)  # In one week.
-    expiration_timestamp = \
-        int((expiration - datetime(1970, 1, 1)).total_seconds())
-
-    email_encoded = base64.b64encode(email)
-    email_hash = _generate_hash('email', email)
-    timestamp_hash = hmac.new(
-        secret_key, email_encoded + str(expiration_timestamp), sha1)
-
-    return (email_encoded, email_hash, expiration_timestamp,
-            timestamp_hash.hexdigest())
-
-
-def generate_unsubscribe_path(email):
-    email_encoded, _, timestamp, timestamp_hash = \
-        generate_email_signature(email)
-
-    return reverse('unsubscribe', kwargs={
-        'email_encoded': email_encoded,
-        'expiration': timestamp,
-        'signature': timestamp_hash,
-    })
-
-
-def verify_email_signature(email_encoded, expiration, signature):
-    secret_key = settings.UNSUBSCRIBE_SECRET_KEY
-
-    hashed = hmac.new(secret_key, email_encoded + expiration, sha1)
-    return hmac.compare_digest(hashed.hexdigest(), str(signature))

--- a/apps/mainsite/blacklist.py
+++ b/apps/mainsite/blacklist.py
@@ -27,44 +27,42 @@ def api_submit_recipient_id(id_type, recipient_id):
         return None
 
 
-def api_query_recipient_id(id_type, recipient_id):
-    blacklist_api_key = getattr(settings, 'BADGR_BLACKLIST_API_KEY', None)
-    blacklist_query_endpoint = getattr(settings, 'BADGR_BLACKLIST_QUERY_ENDPOINT', None)
-    if blacklist_api_key and blacklist_query_endpoint:
-        recipient_id_hash = generate_hash(id_type, recipient_id)
+def api_query_recipient_id(id_type, recipient_id, blacklist_query_endpoint, blacklist_api_key):
+    recipient_id_hash = generate_hash(id_type, recipient_id)
+    request_query = "{endpoint}?id={recipient_id_hash}".format(
+        endpoint=blacklist_query_endpoint,
+        recipient_id_hash=recipient_id_hash)
 
-        request_query = "{endpoint}?id={recipient_id_hash}".format(
-            endpoint=blacklist_query_endpoint,
-            recipient_id_hash=recipient_id_hash)
-
-        try:
-            response = requests.get(request_query, headers={
-                "Authorization": "BEARER {api_key}".format(
-                    api_key=blacklist_api_key
-                ),
-            })
-        except ConnectionError:
-            return None
-
-        return response
-    else:
+    try:
+        response = requests.get(request_query, headers={
+            "Authorization": "BEARER {api_key}".format(
+                api_key=blacklist_api_key
+            ),
+        })
+    except ConnectionError:
         return None
+
+    return response
 
 
 def api_query_is_in_blacklist(id_type, recipient_id):
-    response = api_query_recipient_id(id_type, recipient_id)
+    blacklist_api_key = getattr(settings, 'BADGR_BLACKLIST_API_KEY', None)
+    blacklist_query_endpoint = getattr(settings, 'BADGR_BLACKLIST_QUERY_ENDPOINT', None)
+    if blacklist_query_endpoint and blacklist_api_key:
+        response = api_query_recipient_id(id_type, recipient_id, blacklist_query_endpoint, blacklist_api_key)
 
-    if response and response.status_code == 200:
-        query = response.json()
-        if len(query) > 0:
-            return True
-        else:
-            return False
+        if response and response.status_code == 200:
+            query = response.json()
+            if len(query) > 0:
+                return True
+            else:
+                return False
 
-    if response is None:
-        raise Exception("Blacklist failed to respond")
+        if response is None:
+            raise Exception("Blacklist failed to respond")
 
-    return None
+        return False
+    return False
 
 
 def generate_hash(id_type, id_value):

--- a/apps/mainsite/blacklist.py
+++ b/apps/mainsite/blacklist.py
@@ -5,13 +5,12 @@ from requests.exceptions import ConnectionError
 
 from django.conf import settings
 
-blacklist_api_key = getattr(settings, 'BADGR_BLACKLIST_API_KEY', None)
-blacklist_query_endpoint = getattr(settings, 'BADGR_BLACKLIST_QUERY_ENDPOINT', None)
-
 
 def api_submit_recipient_id(id_type, recipient_id):
+    blacklist_api_key = getattr(settings, 'BADGR_BLACKLIST_API_KEY', None)
+    blacklist_query_endpoint = getattr(settings, 'BADGR_BLACKLIST_QUERY_ENDPOINT', None)
     if blacklist_api_key and blacklist_query_endpoint:
-        recipient_id_hash = _generate_hash(id_type, recipient_id)
+        recipient_id_hash = generate_hash(id_type, recipient_id)
 
         try:
             response = requests.post(
@@ -29,8 +28,10 @@ def api_submit_recipient_id(id_type, recipient_id):
 
 
 def api_query_recipient_id(id_type, recipient_id):
+    blacklist_api_key = getattr(settings, 'BADGR_BLACKLIST_API_KEY', None)
+    blacklist_query_endpoint = getattr(settings, 'BADGR_BLACKLIST_QUERY_ENDPOINT', None)
     if blacklist_api_key and blacklist_query_endpoint:
-        recipient_id_hash = _generate_hash(id_type, recipient_id)
+        recipient_id_hash = generate_hash(id_type, recipient_id)
 
         request_query = "{endpoint}?id={recipient_id_hash}".format(
             endpoint=blacklist_query_endpoint,
@@ -59,10 +60,12 @@ def api_query_is_in_blacklist(id_type, recipient_id):
             return True
         else:
             return False
-
+    # The assertion should not be created
+    # Raise blacklist not configured: blacklist_api_key blacklist_query_endpoint
+    raise Exception("")
     return None
 
 
-def _generate_hash(id_type, id_value):
+def generate_hash(id_type, id_value):
     return "${id_type}$sha256${hash}".format(id_type=id_type,
                                              hash=sha256(id_value).hexdigest())

--- a/apps/mainsite/blacklist.py
+++ b/apps/mainsite/blacklist.py
@@ -61,7 +61,7 @@ def api_query_is_in_blacklist(id_type, recipient_id):
         else:
             return False
 
-    if not response:
+    if response is None:
         raise Exception("Blacklist failed to respond")
 
     return None

--- a/apps/mainsite/models.py
+++ b/apps/mainsite/models.py
@@ -1,35 +1,24 @@
-import StringIO
-import abc
 import base64
-import os
 import re
 import urlparse
 
-import basic_models
 from datetime import datetime, timedelta
-from hashlib import sha1, md5
+from hashlib import sha1
 import hmac
-import uuid
 
-import requests
-from basic_models.managers import ActiveObjectsManager
 from basic_models.models import CreatedUpdatedBy, CreatedUpdatedAt, IsActive
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.core.files.storage import DefaultStorage
 from django.core.urlresolvers import reverse
 from django.db import models
 
-from autoslug import AutoSlugField
 import cachemodel
 from django.db.models import Manager
 from django.utils.deconstruct import deconstructible
-from jsonfield import JSONField
 from oauth2_provider.models import AccessToken
 from rest_framework.authtoken.models import Token
 
-from mainsite.utils import OriginSetting, fetch_remote_file_to_storage
-from .mixins import ResizeUploadedImage
+from mainsite.utils import OriginSetting
 
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')

--- a/apps/mainsite/tests/test_misc.py
+++ b/apps/mainsite/tests/test_misc.py
@@ -223,6 +223,10 @@ class TestBlacklist(BadgrTestCase):
         in_blacklist = blacklist.api_query_is_in_blacklist(id_type, id_value)
         self.assertFalse(in_blacklist)
 
+    def test_blacklist_not_configured_throws_exception(self):
+        id_type, id_value = self.Inputs[1]
+        self.assertRaises(Exception, blacklist.api_query_is_in_blacklist(id_type, id_value))
+
     def test_blacklistgenerate_hash(self):
         # The generate_hash function implementation should not change; We risk contacting people on the blacklist
         for (id_type, id_value) in self.Inputs:

--- a/apps/mainsite/tests/test_misc.py
+++ b/apps/mainsite/tests/test_misc.py
@@ -201,7 +201,7 @@ class TestBlacklist(BadgrTestCase):
     @responses.activate
     def test_blacklist_assertion_to_recipient_in_blacklist(self):
         id_type, id_value = self.Inputs[0]
-        with mock.patch('mainsite.blacklist.api_query_is_in_blacklist', new=lambda _: True):
+        with mock.patch('mainsite.blacklist.api_query_is_in_blacklist', new=lambda a, b: True):
             BadgeInstance.objects.create(
                 recipient_identifier="test@example.com",
                 badgeclass=self.badge_class,
@@ -225,8 +225,9 @@ class TestBlacklist(BadgrTestCase):
 
     def test_blacklist_not_configured_throws_exception(self):
         id_type, id_value = self.Inputs[1]
-        with mock.patch('mainsite.blacklist.api_query_recipient_id', new=lambda _: None):
-            self.assertRaises(Exception, blacklist.api_query_is_in_blacklist(id_type, id_value))
+        with mock.patch('mainsite.blacklist.api_query_recipient_id', new=lambda a, b, c, d: None):
+            with self.assertRaises(Exception):
+                blacklist.api_query_is_in_blacklist(id_type, id_value)
 
     def test_blacklistgenerate_hash(self):
         # The generate_hash function implementation should not change; We risk contacting people on the blacklist

--- a/apps/mainsite/tests/test_misc.py
+++ b/apps/mainsite/tests/test_misc.py
@@ -150,10 +150,6 @@ class TestEmailCleanupCommand(BadgrTestCase):
         self.assertEqual(BadgeUser.objects.count(), 1)
 
 
-@override_settings(
-    BADGR_BLACKLIST_API_KEY='123',
-    BADGR_BLACKLIST_QUERY_ENDPOINT='http://example.com',
-)
 class TestBlacklist(BadgrTestCase):
     def setUp(self):
         super(TestBlacklist, self).setUp()
@@ -186,6 +182,10 @@ class TestBlacklist(BadgrTestCase):
               ('telephone', '+16175551212'),
               ]
 
+    @override_settings(
+        BADGR_BLACKLIST_API_KEY='123',
+        BADGR_BLACKLIST_QUERY_ENDPOINT='http://example.com',
+    )
     @responses.activate
     def test_blacklist_api_query_is_in_blacklist(self):
         id_type, id_value = self.Inputs[0]
@@ -198,6 +198,10 @@ class TestBlacklist(BadgrTestCase):
         in_blacklist = blacklist.api_query_is_in_blacklist(id_type, id_value)
         self.assertTrue(in_blacklist)
 
+    @override_settings(
+        BADGR_BLACKLIST_API_KEY='123',
+        BADGR_BLACKLIST_QUERY_ENDPOINT='http://example.com',
+    )
     @responses.activate
     def test_blacklist_assertion_to_recipient_in_blacklist(self):
         id_type, id_value = self.Inputs[0]
@@ -211,6 +215,10 @@ class TestBlacklist(BadgrTestCase):
             )
         self.assertIsNone(BadgeInstance.objects.first())
 
+    @override_settings(
+        BADGR_BLACKLIST_API_KEY='123',
+        BADGR_BLACKLIST_QUERY_ENDPOINT='http://example.com',
+    )
     @responses.activate
     def test_blacklist_api_query_is_in_blacklist_false(self):
         id_type, id_value = self.Inputs[1]
@@ -223,12 +231,20 @@ class TestBlacklist(BadgrTestCase):
         in_blacklist = blacklist.api_query_is_in_blacklist(id_type, id_value)
         self.assertFalse(in_blacklist)
 
+    @override_settings(
+        BADGR_BLACKLIST_API_KEY='123',
+        BADGR_BLACKLIST_QUERY_ENDPOINT='http://example.com',
+    )
     def test_blacklist_not_configured_throws_exception(self):
         id_type, id_value = self.Inputs[1]
         with mock.patch('mainsite.blacklist.api_query_recipient_id', new=lambda a, b, c, d: None):
             with self.assertRaises(Exception):
                 blacklist.api_query_is_in_blacklist(id_type, id_value)
 
+    @override_settings(
+        BADGR_BLACKLIST_API_KEY='123',
+        BADGR_BLACKLIST_QUERY_ENDPOINT='http://example.com',
+    )
     def test_blacklistgenerate_hash(self):
         # The generate_hash function implementation should not change; We risk contacting people on the blacklist
         for (id_type, id_value) in self.Inputs:

--- a/apps/mainsite/tests/test_misc.py
+++ b/apps/mainsite/tests/test_misc.py
@@ -201,7 +201,7 @@ class TestBlacklist(BadgrTestCase):
     @responses.activate
     def test_blacklist_assertion_to_recipient_in_blacklist(self):
         id_type, id_value = self.Inputs[0]
-        with mock.patch('mainsite.blacklist.api_query_is_in_blacklist', new=lambda type, val: True):
+        with mock.patch('mainsite.blacklist.api_query_is_in_blacklist', new=lambda _: True):
             BadgeInstance.objects.create(
                 recipient_identifier="test@example.com",
                 badgeclass=self.badge_class,
@@ -225,7 +225,8 @@ class TestBlacklist(BadgrTestCase):
 
     def test_blacklist_not_configured_throws_exception(self):
         id_type, id_value = self.Inputs[1]
-        self.assertRaises(Exception, blacklist.api_query_is_in_blacklist(id_type, id_value))
+        with mock.patch('mainsite.blacklist.api_query_recipient_id', new=lambda _: None):
+            self.assertRaises(Exception, blacklist.api_query_is_in_blacklist(id_type, id_value))
 
     def test_blacklistgenerate_hash(self):
         # The generate_hash function implementation should not change; We risk contacting people on the blacklist

--- a/apps/mainsite/tests/test_misc.py
+++ b/apps/mainsite/tests/test_misc.py
@@ -150,15 +150,13 @@ class TestEmailCleanupCommand(BadgrTestCase):
 
 class TestBlacklist(BadgrTestCase):
     def test_blacklist_generate_hash(self):
-        # The generate_hash function implementation should not change; We risk contacting people on the blacklist
+        # The _generate_hash function implementation should not change; We risk contacting people on the blacklist
         inputs = [('email', 'test@example.com'),
                   ('url', 'http://example.com'),
                   ('telephone', '+16175551212'),
                   ]
 
         for (id_type, id_value) in inputs:
-            got = blacklist.generate_hash(id_type, id_value)
+            got = blacklist._generate_hash(id_type, id_value)
             expected = "${id_type}$sha256${hash}".format(id_type=id_type, hash=sha256(id_value).hexdigest())
             self.assertEqual(got, expected)
-
-

--- a/apps/mainsite/tests/test_misc.py
+++ b/apps/mainsite/tests/test_misc.py
@@ -15,6 +15,8 @@ from mainsite import TOP_DIR, blacklist
 from mainsite.tests.base import BadgrTestCase
 from hashlib import sha256
 import responses
+from issuer.models import BadgeClass, Issuer, BadgeInstance
+import mock
 
 
 class TestCacheSettings(TransactionTestCase):
@@ -153,6 +155,32 @@ class TestEmailCleanupCommand(BadgrTestCase):
     BADGR_BLACKLIST_QUERY_ENDPOINT='http://example.com',
 )
 class TestBlacklist(BadgrTestCase):
+    def setUp(self):
+        super(TestBlacklist, self).setUp()
+        self.user, _ = BadgeUser.objects.get_or_create(email='test@example.com')
+        self.cached_email, _ = CachedEmailAddress.objects.get_or_create(user=self.user, email='test@example.com', verified=True, primary=True)
+        self.issuer = Issuer.objects.create(
+            name="Open Badges",
+            created_at="2015-12-15T15:55:51Z",
+            created_by=None,
+            slug="open-badges",
+            source_url="http://badger.openbadges.org/program/meta/bda68a0b505bc0c7cf21bc7900280ee74845f693",
+            source="test-fixture",
+            image=""
+        )
+
+        self.badge_class = BadgeClass.objects.create(
+            name="MozFest Reveler",
+            created_at="2015-12-15T15:55:51Z",
+            created_by=None,
+            slug="mozfest-reveler",
+            criteria_text=None,
+            source_url="http://badger.openbadges.org/badge/meta/mozfest-reveler",
+            source="test-fixture",
+            image="",
+            issuer=self.issuer
+        )
+
     Inputs = [('email', 'test@example.com'),
               ('url', 'http://example.com'),
               ('telephone', '+16175551212'),
@@ -163,7 +191,7 @@ class TestBlacklist(BadgrTestCase):
         id_type, id_value = self.Inputs[0]
 
         responses.add(
-            responses.GET, 'http://example.com?id='+blacklist._generate_hash(id_type, id_value),
+            responses.GET, 'http://example.com?id='+blacklist.generate_hash(id_type, id_value),
             body="{\"msg\": \"ok\"}", status=200
         )
 
@@ -171,20 +199,33 @@ class TestBlacklist(BadgrTestCase):
         self.assertTrue(in_blacklist)
 
     @responses.activate
+    def test_blacklist_assertion_to_recipient_in_blacklist(self):
+        id_type, id_value = self.Inputs[0]
+        with mock.patch('mainsite.blacklist.api_query_is_in_blacklist', new=lambda type, val: True):
+            BadgeInstance.objects.create(
+                recipient_identifier="test@example.com",
+                badgeclass=self.badge_class,
+                issuer=self.issuer,
+                image="uploads/badges/local_badgeinstance_174e70bf-b7a8-4b71-8125-c34d1a994a7c.png",
+                acceptance=BadgeInstance.ACCEPTANCE_ACCEPTED
+            )
+        self.assertIsNone(BadgeInstance.objects.first())
+
+    @responses.activate
     def test_blacklist_api_query_is_in_blacklist_false(self):
         id_type, id_value = self.Inputs[1]
 
         responses.add(
-            responses.GET, 'http://example.com?id='+blacklist._generate_hash(id_type, id_value),
+            responses.GET, 'http://example.com?id='+blacklist.generate_hash(id_type, id_value),
             body="{\"msg\": \"no\"}", status=404
         )
 
         in_blacklist = blacklist.api_query_is_in_blacklist(id_type, id_value)
         self.assertFalse(in_blacklist)
 
-    def test_blacklist_generate_hash(self):
-        # The _generate_hash function implementation should not change; We risk contacting people on the blacklist
+    def test_blacklistgenerate_hash(self):
+        # The generate_hash function implementation should not change; We risk contacting people on the blacklist
         for (id_type, id_value) in self.Inputs:
-            got = blacklist._generate_hash(id_type, id_value)
+            got = blacklist.generate_hash(id_type, id_value)
             expected = "${id_type}$sha256${hash}".format(id_type=id_type, hash=sha256(id_value).hexdigest())
             self.assertEqual(got, expected)


### PR DESCRIPTION
 - [x] Update blacklist utils to operate with non-email hash "type"
 - [x] Call `generate_hash` with `url`, `telephone`, `email` based on context
 - [x] Write tests
 - [x] Raise exception if blacklist not configured properly
 - [x] Don't store blacklisted recipient ids in logs, only the hash and the badge class entity id