### PR TITLE
Bugfix/bgr 4001 optional verification email

### DIFF
--- a/apps/badgrsocialauth/providers/google/tests.py
+++ b/apps/badgrsocialauth/providers/google/tests.py
@@ -1,0 +1,29 @@
+from allauth.tests import MockedResponse
+
+from badgrsocialauth.providers.google.provider import UnverifiedGoogleProvider
+from badgrsocialauth.providers.tests.base import BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase
+from badgrsocialauth.providers.tests.test_third_party import SendsVerificationEmailMixin
+
+
+class UnverifiedGoogleProviderTests(SendsVerificationEmailMixin, BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase):
+    provider_id = UnverifiedGoogleProvider.id
+
+    def get_mocked_response(self,
+                            family_name='Penners',
+                            given_name='Raymond',
+                            name='Raymond Penners',
+                            email="raymond.penners@example.com",
+                            verified_email=True):
+        return MockedResponse(200, """
+              {"family_name": "%s", "name": "%s",
+               "picture": "https://lh5.googleusercontent.com/photo.jpg",
+               "locale": "nl", "gender": "male",
+               "email": "%s",
+               "link": "https://plus.google.com/108204268033311374519",
+               "given_name": "%s", "id": "108204268033311374519",
+               "verified_email": %s }
+        """ % (family_name,
+               name,
+               email,
+               given_name,
+               (repr(verified_email).lower())))

--- a/apps/badgrsocialauth/providers/kony/tests.py
+++ b/apps/badgrsocialauth/providers/kony/tests.py
@@ -1,0 +1,20 @@
+from allauth.tests import MockedResponse
+
+from .provider import KonyProvider
+from ..tests.base import BadgrSocialAuthTestCase, BadgrOAuthTestsMixin, SendsVerificationEmailMixin
+
+
+class KonyProviderTests(SendsVerificationEmailMixin, BadgrOAuthTestsMixin, BadgrSocialAuthTestCase):
+    provider_id = KonyProvider.id
+
+    def get_mocked_response(self):
+        # inferred by looking at KonyProvider implementation
+        return [
+            MockedResponse(200, """
+            {
+              "primary_email": "raymond.penners@intenct.nl",
+              "first_name": "Raymond",
+              "user_guid": "ZLARGMFT1M",
+              "last_name": "Penners"
+            }""")
+        ]

--- a/apps/badgrsocialauth/providers/tests/base.py
+++ b/apps/badgrsocialauth/providers/tests/base.py
@@ -1,0 +1,42 @@
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from django.test import override_settings
+from django.urls import reverse
+from mainsite.tests import BadgrTestCase
+
+
+class BadgrOAuth2TestsMixin(OAuth2TestsMixin):
+    """
+    Tests for OAuth2Provider subclasses in this application should use this
+    mixin instead of OAuth2TestsMixin.
+
+    Default tests include expectations broken by BadgrAccountAdapter, and
+    this overrides those to make more sense.
+    """
+    def test_authentication_error(self):
+        # override: base implementation looks for a particular template to be rendered.
+        resp = self.client.get(reverse(self.provider.id + '_callback'))
+        # Tried assertRedirects here, but don't want to couple this to the query params
+        self.assertIn(self.badgr_app.ui_login_redirect, resp['Location'])
+
+    def test_login(self):
+        # override: base implementation uses assertRedirects, but we need to
+        # allow for query params.
+        response = self.login(self.get_mocked_response())
+        self.assertEqual(response.status_code, 302)
+        redirect_url, query_string = response.url.split('?')
+        self.assertRegex(query_string, r'^authToken=[^\s]+$')
+        self.assertEqual(redirect_url, self.badgr_app.ui_login_redirect)
+
+
+@override_settings(UNSUBSCRIBE_SECRET_KEY='123a')
+class BadgrSocialAuthTestCase(BadgrTestCase):
+    def setUp(self):
+        super(BadgrSocialAuthTestCase, self).setUp()
+        self.badgr_app.ui_login_redirect = 'http://test-badgr.io/'
+        self.badgr_app.save()
+
+        session = self.client.session
+        session.update({
+            'badgr_app_pk': self.badgr_app.pk
+        })
+        session.save()

--- a/apps/badgrsocialauth/providers/tests/test_third_party.py
+++ b/apps/badgrsocialauth/providers/tests/test_third_party.py
@@ -1,0 +1,41 @@
+from allauth.socialaccount.providers.facebook.provider import FacebookProvider
+from allauth.tests import MockedResponse
+from django.core import mail
+
+from .base import BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase
+
+
+class FacebookProviderTests(BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase):
+    provider_id = FacebookProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(200, """
+        {
+           "id": "630595557",
+           "name": "Raymond Penners",
+           "first_name": "Raymond",
+           "last_name": "Penners",
+           "email": "raymond.penners@example.com",
+           "link": "https://www.facebook.com/raymond.penners",
+           "username": "raymond.penners",
+           "birthday": "07/17/1973",
+           "work": [
+              {
+                 "employer": {
+                    "id": "204953799537777",
+                    "name": "IntenCT"
+                 }
+              }
+           ],
+           "timezone": 1,
+           "locale": "nl_NL",
+           "verified": true,
+           "updated_time": "2012-11-30T20:40:33+0000"
+        }""")
+
+    def test_verification_email(self):
+        # Expect this provider to send a verification email on first login
+        before_count = len(mail.outbox)
+        response = self.login(self.get_mocked_response())
+        self.assertEqual(response.status_code, 302)  # sanity
+        self.assertEqual(len(mail.outbox), before_count + 1)

--- a/apps/badgrsocialauth/providers/tests/test_third_party.py
+++ b/apps/badgrsocialauth/providers/tests/test_third_party.py
@@ -1,18 +1,8 @@
 from allauth.socialaccount.providers.facebook.provider import FacebookProvider
 from allauth.socialaccount.providers.linkedin_oauth2.provider import LinkedInOAuth2Provider
 from allauth.tests import MockedResponse
-from django.core import mail
 
-from .base import BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase
-
-
-class SendsVerificationEmailMixin(object):
-    def test_verification_email(self):
-        # Expect this provider to send a verification email on first login
-        before_count = len(mail.outbox)
-        response = self.login(self.get_mocked_response())
-        self.assertEqual(response.status_code, 302)  # sanity
-        self.assertEqual(len(mail.outbox), before_count + 1)
+from .base import BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase, SendsVerificationEmailMixin
 
 
 class FacebookProviderTests(SendsVerificationEmailMixin, BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase):

--- a/apps/mainsite/account_adapter.py
+++ b/apps/mainsite/account_adapter.py
@@ -97,9 +97,11 @@ class BadgrAccountAdapter(DefaultAccountAdapter):
 
         # Add source and signup query params to the confimation url
         if request:
-            if hasattr(request, 'session'):
+            source = None
+            if hasattr(request, 'data'):
+                source = request.data.get('source', None)
+            elif hasattr(request, 'session'):
                 source = request.session.get('source', None)
-            source = request.data.get('source', None)
 
             if source:
                 tokenized_activate_url = set_url_query_params(tokenized_activate_url, source=source)

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -172,7 +172,8 @@ ACCOUNT_FORMS = {
 ACCOUNT_SIGNUP_FORM_CLASS = 'badgeuser.forms.BadgeUserCreationForm'
 
 
-SOCIALACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+SOCIALACCOUNT_EMAIL_REQUIRED = False
+SOCIALACCOUNT_EMAIL_VERIFICATION = 'optional'
 SOCIALACCOUNT_PROVIDERS = {
     'kony': {
         'environment': 'dev'


### PR DESCRIPTION
Updated settings to reflect that emails are optional for social accounts.

Added tests for Google, Facebook, LinkedIn and Kony providers.
