### PR TITLE
Add support for filter by multiple recipients

### DIFF
--- a/apps/issuer/api.py
+++ b/apps/issuer/api.py
@@ -355,10 +355,9 @@ class BadgeInstanceList(UncachedPaginatedViewMixin, VersionedObjectMixin, BaseEn
             badgeclass=badgeclass,
             revoked=False
         )
-
-        if 'recipient' in request.query_params:
-            recipient_id = request.query_params.get('recipient').lower()
-            queryset = queryset.filter(recipient_identifier=recipient_id)
+        recipients = request.query_params.getlist('recipient', None)
+        if recipients:
+            queryset = queryset.filter(recipient_identifier__in=recipients)
 
         return queryset
 

--- a/apps/issuer/api.py
+++ b/apps/issuer/api.py
@@ -423,10 +423,9 @@ class IssuerBadgeInstanceList(UncachedPaginatedViewMixin, VersionedObjectMixin, 
             issuer=issuer,
             revoked=False
         )
-
-        if 'recipient' in request.query_params:
-            recipient_id = request.query_params.get('recipient').lower()
-            queryset = queryset.filter(recipient_identifier=recipient_id)
+        recipients = request.query_params.getlist('recipient', None)
+        if recipients:
+            queryset = queryset.filter(recipient_identifier__in=recipients)
 
         return queryset
 

--- a/apps/issuer/tests/test_v2_api.py
+++ b/apps/issuer/tests/test_v2_api.py
@@ -6,7 +6,44 @@ from mainsite.tests import SetupIssuerHelper, BadgrTestCase
 
 
 class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
+    def test_can_fetch_assertions_by_recipient_ids_for_badgeclass(self):
+        user1 = self.setup_user(authenticate=True, email='user1@example.com')
+        user2 = self.setup_user(email='user2@example.com')
+        user3 = self.setup_user(email='user3@example.com')
+        issuer = self.setup_issuer(owner=user1)
+        badgeclass = self.setup_badgeclass(issuer=issuer)
 
+        badgeclass.issue(recipient_id=user1.email)
+        badgeclass.issue(recipient_id=user2.email)
+        badgeclass.issue(recipient_id=user3.email)
+
+        # Test default case without any filtering
+        url = "{url}".format(
+            url=reverse('v2_api_badgeclass_assertion_list', kwargs={'entity_id': badgeclass.entity_id}),
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['result']), 3)
+        
+        # Filter for 1 recipient
+        url = "{url}?recipient={email2}".format(
+            url=reverse('v2_api_badgeclass_assertion_list', kwargs={'entity_id': badgeclass.entity_id}),
+            email2=user2.email
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['result']), 1)
+        
+        # Filter for 2 recipient
+        url = "{url}?recipient={email2}&recipient={email3}".format(
+            url=reverse('v2_api_badgeclass_assertion_list', kwargs={'entity_id': badgeclass.entity_id}),
+            email2=user2.email,
+            email3=user3.email
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['result']), 2)
+        
     def test_can_fetch_assertions_by_recipient_ids(self):
         user1 = self.setup_user(authenticate=True, email='user1@example.com')
         user2 = self.setup_user(email='user2@example.com')

--- a/apps/issuer/tests/test_v2_api.py
+++ b/apps/issuer/tests/test_v2_api.py
@@ -6,6 +6,26 @@ from mainsite.tests import SetupIssuerHelper, BadgrTestCase
 
 
 class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
+    def test_can_paginate_fetch_assertions_by_recipient(self):
+        user1 = self.setup_user(authenticate=True, email='user1@example.com')
+        user2 = self.setup_user(email='user2@example.com')
+        user3 = self.setup_user(email='user3@example.com')
+        issuer = self.setup_issuer(owner=user1)
+        badgeclass = self.setup_badgeclass(issuer=issuer)
+
+        badgeclass.issue(recipient_id=user1.email)
+        badgeclass.issue(recipient_id=user2.email)
+        badgeclass.issue(recipient_id=user3.email)
+
+        url = "{url}?num=2&recipient={email3}".format(
+            url=reverse('v2_api_badgeclass_assertion_list',
+                        kwargs={'entity_id': badgeclass.entity_id}),
+            email3=user3.email
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['result']), 1)
+
     def test_can_fetch_assertions_by_recipient_ids_for_badgeclass(self):
         user1 = self.setup_user(authenticate=True, email='user1@example.com')
         user2 = self.setup_user(email='user2@example.com')
@@ -24,7 +44,7 @@ class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['result']), 3)
-        
+
         # Filter for 1 recipient
         url = "{url}?recipient={email2}".format(
             url=reverse('v2_api_badgeclass_assertion_list', kwargs={'entity_id': badgeclass.entity_id}),
@@ -33,7 +53,7 @@ class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['result']), 1)
-        
+
         # Filter for 2 recipient
         url = "{url}?recipient={email2}&recipient={email3}".format(
             url=reverse('v2_api_badgeclass_assertion_list', kwargs={'entity_id': badgeclass.entity_id}),
@@ -43,7 +63,7 @@ class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['result']), 2)
-        
+
     def test_can_fetch_assertions_by_recipient_ids(self):
         user1 = self.setup_user(authenticate=True, email='user1@example.com')
         user2 = self.setup_user(email='user2@example.com')
@@ -62,7 +82,7 @@ class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['result']), 3)
-        
+
         # Filter for 1 recipient
         url = "{url}?recipient={email2}".format(
             url=reverse('v2_api_issuer_assertion_list', kwargs={'entity_id': issuer.entity_id}),
@@ -71,7 +91,7 @@ class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['result']), 1)
-        
+
         # Filter for 2 recipient
         url = "{url}?recipient={email2}&recipient={email3}".format(
             url=reverse('v2_api_issuer_assertion_list', kwargs={'entity_id': issuer.entity_id}),
@@ -81,5 +101,3 @@ class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['result']), 2)
-
-        

--- a/apps/issuer/tests/test_v2_api.py
+++ b/apps/issuer/tests/test_v2_api.py
@@ -1,0 +1,48 @@
+# encoding: utf-8
+from __future__ import unicode_literals
+
+from django.core.urlresolvers import reverse
+from mainsite.tests import SetupIssuerHelper, BadgrTestCase
+
+
+class AssertionFetching(SetupIssuerHelper, BadgrTestCase):
+
+    def test_can_fetch_assertions_by_recipient_ids(self):
+        user1 = self.setup_user(authenticate=True, email='user1@example.com')
+        user2 = self.setup_user(email='user2@example.com')
+        user3 = self.setup_user(email='user3@example.com')
+        issuer = self.setup_issuer(owner=user1)
+        badgeclass = self.setup_badgeclass(issuer=issuer)
+
+        badgeclass.issue(recipient_id=user1.email)
+        badgeclass.issue(recipient_id=user2.email)
+        badgeclass.issue(recipient_id=user3.email)
+
+        # Test default case without any filtering
+        url = "{url}".format(
+            url=reverse('v2_api_issuer_assertion_list', kwargs={'entity_id': issuer.entity_id}),
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['result']), 3)
+        
+        # Filter for 1 recipient
+        url = "{url}?recipient={email2}".format(
+            url=reverse('v2_api_issuer_assertion_list', kwargs={'entity_id': issuer.entity_id}),
+            email2=user2.email
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['result']), 1)
+        
+        # Filter for 2 recipient
+        url = "{url}?recipient={email2}&recipient={email3}".format(
+            url=reverse('v2_api_issuer_assertion_list', kwargs={'entity_id': issuer.entity_id}),
+            email2=user2.email,
+            email3=user3.email
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['result']), 2)
+
+        


### PR DESCRIPTION
Adds support for `?recipient=id1&recipient=id2` filtering. Previously only `?recipient=id1` was supported. This change is backwards compatible. Affected endpoints:

```
/v2/badgeclasses/<entity_id>/assertions	issuer.api.BadgeInstanceList	v2_api_badgeclass_assertion_list
/v2/issuers/<entity_id>/assertions	issuer.api.IssuerBadgeInstanceList	v2_api_issuer_assertion_list
```