### PR TITLE
Bugfix/bgr 4262 issuer list desync

### DIFF
--- a/apps/issuer/api_v1.py
+++ b/apps/issuer/api_v1.py
@@ -199,7 +199,7 @@ class IssuerStaffList(VersionedObjectMixin, APIView):
 
         elif action == 'remove':
             IssuerStaff.objects.filter(user=user_to_modify, issuer=current_issuer).delete()
-            current_issuer.publish()
+            current_issuer.publish(publish_staff=False)
             user_to_modify.publish()
             return Response(
                 "User %s has been removed from %s staff." % (user_to_modify.username, current_issuer.name),

--- a/apps/issuer/tests/test_issuer.py
+++ b/apps/issuer/tests/test_issuer.py
@@ -122,6 +122,15 @@ class IssuerTests(SetupIssuerHelper, BadgrTestCase):
         self.assertEqual(response.data['description'], updated_issuer_props['description'])
         self.assertEqual(response.data['email'], updated_issuer_props['email'])
 
+        # test that subsequent GETs include the updated data
+        response = self.client.get('/v2/issuers')
+        response_issuers = response.data['result']
+        self.assertEqual(len(response_issuers), 1)
+        self.assertEqual(response_issuers[0]['url'], updated_issuer_props['url'])
+        self.assertEqual(response_issuers[0]['name'], updated_issuer_props['name'])
+        self.assertEqual(response_issuers[0]['description'], updated_issuer_props['description'])
+        self.assertEqual(response_issuers[0]['email'], updated_issuer_props['email'])
+
     def test_get_empty_issuer_editors_set(self):
         test_user = self.setup_user(authenticate=True)
         issuer = self.setup_issuer(owner=test_user)

--- a/apps/pathway/models.py
+++ b/apps/pathway/models.py
@@ -31,12 +31,12 @@ class Pathway(cachemodel.CacheModel, IsActive):
     def publish(self):
         super(Pathway, self).publish()
         self.publish_by('slug')
-        self.issuer.publish()
+        self.issuer.publish(publish_staff=False)
 
     def delete(self, *args, **kwargs):
         issuer = self.issuer
         ret = super(Pathway, self).delete(*args, **kwargs)
-        issuer.publish()
+        issuer.publish(publish_staff=False)
         return ret
 
     @property

--- a/apps/recipient/models.py
+++ b/apps/recipient/models.py
@@ -83,11 +83,11 @@ class RecipientGroup(BaseAuditedModel, BaseVersionedEntity, IsActive):
 
     def publish(self):
         super(RecipientGroup, self).publish()
-        self.issuer.publish()
+        self.issuer.publish(publish_staff=False)
 
     def delete(self, *args, **kwargs):
         ret = super(RecipientGroup, self).delete(*args, **kwargs)
-        self.issuer.publish()
+        self.issuer.publish(publish_staff=False)
         return ret
 
     @property


### PR DESCRIPTION
Updated to publish Issuer staff by default. In the default case, it is the issuer object being updated and the corresponding staff users should have their cached issuer lists updated to reflect the change.

When the Issuer instance is saved (e.g., by a serializer update method), the CacheModel base class calls publish with no params. There's no mechanism for overriding the behavior. This also makes it simplest to change the default to accommodate the Issuer.save case.

We could instead call publish again with publish_staff=True in these cases, but I'd say publishing staff by default feels more correct.