### PR TITLE
Protect against email settings containing names, add logging for render

### DIFF
--- a/apps/badgrlog/events/__init__.py
+++ b/apps/badgrlog/events/__init__.py
@@ -1,7 +1,6 @@
-# Created by wiggins@concentricsky.com on 8/27/15.
-
+from .badgeuser import *
+from .blacklist import *
+from .composition import *
+from .email import *
 from .issuer import *
 from .public import *
-from .badgeuser import *
-from .composition import *
-from .blacklist import *

--- a/apps/badgrlog/events/base.py
+++ b/apps/badgrlog/events/base.py
@@ -6,16 +6,12 @@ class BaseBadgrEvent(object):
     def get_type(self):
         return self.__class__.__name__
 
-    def get_context(self):
-        return "https://badgr.io/json-ld/v1"
-
     def to_representation(self):
         raise NotImplementedError("subclasses must provide a to_representation method")
 
     def compacted(self):
         data = self.to_representation()
         data.update({
-            '@context': self.get_context(),
             'type': 'Action',
             'actionType': self.get_type(),
             'timestamp': datetime.datetime.now().isoformat()

--- a/apps/badgrlog/events/email.py
+++ b/apps/badgrlog/events/email.py
@@ -1,0 +1,13 @@
+from .base import BaseBadgrEvent
+
+
+class EmailRendered(BaseBadgrEvent):
+    def __init__(self, email):
+        self.email = email
+
+    def to_representation(self):
+        return {
+            'subject': self.email.subject,
+            'fromAddress': self.email.from_email,
+            'toAddress': self.email.to
+        }

--- a/apps/mainsite/account_adapter.py
+++ b/apps/mainsite/account_adapter.py
@@ -13,9 +13,12 @@ from django.core.urlresolvers import resolve, Resolver404, reverse
 
 from badgeuser.authcode import authcode_for_accesstoken
 from badgeuser.models import CachedEmailAddress
+import badgrlog
 from badgrsocialauth.utils import set_session_badgr_app
 from mainsite.models import BadgrApp, EmailBlacklist, AccessTokenProxy
 from mainsite.utils import OriginSetting, set_url_query_params
+
+logger = badgrlog.BadgrLogger()
 
 
 class BadgrAccountAdapter(DefaultAccountAdapter):
@@ -43,13 +46,19 @@ class BadgrAccountAdapter(DefaultAccountAdapter):
         self.EMAIL_FROM_STRING = self.set_email_string(context)
 
         msg = self.render_mail(template_prefix, email, context)
+        logger.event(badgrlog.EmailRendered(msg))
         msg.send()
 
     def set_email_string(self, context):
-        from_elements = [context.get('site_name', '')]
+        from_elements = [context.get('site_name', 'Badgr')]
 
-        default_from = getattr(settings, 'DEFAULT_FROM_EMAIL', None)
-        if default_from:
+        # DEFAULT_FROM_EMAIL must not already have < > in it.
+        default_from = getattr(settings, 'DEFAULT_FROM_EMAIL', '')
+        if not default_from:
+            raise NotImplemented("DEFAULT_FROM_EMAIL setting must be defined.")
+        elif '<' in default_from:
+            return default_from
+        else:
             from_elements.append("<{}>".format(default_from))
 
         return " ".join(from_elements)


### PR DESCRIPTION
Adds logging for email rendering as an event, which could assist in cases where email systems error at send time.