### PR TITLE
BP-1590: explicitly set scopes on endpoints for swagger

### DIFF
--- a/apps/issuer/api_v1.py
+++ b/apps/issuer/api_v1.py
@@ -76,7 +76,11 @@ class IssuerStaffList(VersionedObjectMixin, APIView):
         (AuthenticatedWithVerifiedIdentifier & IsOwnerOrStaff) |
         BadgrOAuthTokenHasEntityScope
     ]
-    valid_scopes = ["rw:issuerOwner:*"]
+    valid_scopes = {
+        "get": ["rw:issuerOwner:*"],
+        "post": ["rw:issuerOwner:*"],
+        "@apispec_scopes": {}
+    }
 
     @apispec_list_operation('IssuerStaff',
         tags=['Issuers'],


### PR DESCRIPTION
This depends on concentricsky/apispec-djangorestframework#3