### PR TITLE
Fixed docker build

### DIFF
--- a/.docker/Dockerfile.dev.api
+++ b/.docker/Dockerfile.dev.api
@@ -3,8 +3,6 @@ FROM python:3.7-slim
 RUN mkdir /badgr_server
 WORKDIR /badgr_server
 
-COPY requirements.txt              /badgr_server
-
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y default-libmysqlclient-dev \
                        python3-dev \
@@ -12,7 +10,7 @@ RUN apt-get install -y default-libmysqlclient-dev \
                        build-essential \
                        xmlsec1
 
-RUN pip install -r requirements.txt
 RUN pip install uwsgi
 
-
+COPY requirements.txt              /badgr_server
+RUN pip install -r requirements.txt

--- a/.docker/Dockerfile.prod.api
+++ b/.docker/Dockerfile.prod.api
@@ -3,13 +3,6 @@ FROM python:3.7-slim
 RUN mkdir /badgr_server
 WORKDIR /badgr_server
 
-COPY requirements.txt                   /badgr_server
-COPY manage.py                          /badgr_server
-COPY .docker/etc/uwsgi.ini              /badgr_server
-COPY .docker/etc/wsgi.py                /badgr_server
-COPY apps                               /badgr_server/apps
-COPY .docker/etc/settings_local.prod.py /badgr_server/apps/mainsite/settings_local.py
-
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y default-libmysqlclient-dev \
                        python3-dev \
@@ -17,7 +10,12 @@ RUN apt-get install -y default-libmysqlclient-dev \
                        build-essential \
                        xmlsec1
 
-RUN pip install -r requirements.txt
+COPY requirements.txt                   /badgr_server
+COPY manage.py                          /badgr_server
+COPY .docker/etc/uwsgi.ini              /badgr_server
+COPY .docker/etc/wsgi.py                /badgr_server
+COPY apps                               /badgr_server/apps
+COPY .docker/etc/settings_local.prod.py /badgr_server/apps/mainsite/settings_local.py
+
 RUN pip install uwsgi
-
-
+RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ apispec==0.22.0
 apispec-djangorestframework==1.1.0
 responses==0.8.1
 mock==3.0.5
-django_mock_queries==2.0.0
+django_mock_queries==2.1.5
 
 # lti consumer
 lti==0.9.2


### PR DESCRIPTION
django_mock_queries v2.0.0 was failing on pip install with some `AttributeError: 'ParsedRequirement' object has no attribute 'req'` error. 
Upgrading it to v2.1.5 fix it.

Also reorder layers of Dokerfile, speeding up image rebuild on
requirements.txt changes, making better use of Docker layer caching (current will invalidate the apt layer and force reinstall everything on change).

Full build error:
```
$ docker-compose build
[...]
Step 7/8 : RUN pip install -r requirements.txt
 ---> Running in df315a458c91
Collecting Django==1.11.28
  Downloading Django-1.11.28-py2.py3-none-any.whl (6.9 MB)
[...]
Collecting mock==3.0.5
  Downloading mock-3.0.5-py2.py3-none-any.whl (25 kB)
Collecting django_mock_queries==2.0.0
  Downloading django_mock_queries-2.0.0.tar.gz (17 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-vzkx3dqq/django-mock-queries/setup.py'"'"'; __file__='"'"'/tmp/pip-install-vzkx3dqq/django-mock-queries/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-dtc4krol
         cwd: /tmp/pip-install-vzkx3dqq/django-mock-queries/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-vzkx3dqq/django-mock-queries/setup.py", line 9, in <module>
        req = [str(ir.req) for ir in install_req]
      File "/tmp/pip-install-vzkx3dqq/django-mock-queries/setup.py", line 9, in <listcomp>
        req = [str(ir.req) for ir in install_req]
    AttributeError: 'ParsedRequirement' object has no attribute 'req'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```