### PR TITLE
Add filtering, sorting, pagination and counting for assertions

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -1375,3 +1375,14 @@ class BadgeInstanceExtension(BaseOpenBadgeExtension):
     def delete(self, *args, **kwargs):
         super(BadgeInstanceExtension, self).delete(*args, **kwargs)
         self.badgeinstance.publish()
+
+
+class ListCount(OriginalJsonMixin, cachemodel.CacheModel):
+    count = models.IntegerField(blank=False, null=False, default=0)
+
+    def publish(self):
+        super(ListCount, self).publish()
+
+    def delete(self, *args, **kwargs):
+        ret = super(ListCount, self).delete(*args, **kwargs)
+        return ret

--- a/apps/issuer/serializers_v2.py
+++ b/apps/issuer/serializers_v2.py
@@ -12,7 +12,8 @@ from rest_framework import serializers
 from badgeuser.models import BadgeUser
 from badgeuser.serializers_v2 import BadgeUserEmailSerializerV2
 from entity.serializers import DetailSerializerV2, EntityRelatedFieldV2, BaseSerializerV2
-from issuer.models import Issuer, IssuerStaff, BadgeClass, BadgeInstance, RECIPIENT_TYPE_EMAIL, RECIPIENT_TYPE_ID, RECIPIENT_TYPE_URL, RECIPIENT_TYPE_TELEPHONE
+from issuer.models import Issuer, IssuerStaff, BadgeClass, BadgeInstance, RECIPIENT_TYPE_EMAIL, RECIPIENT_TYPE_ID, \
+    RECIPIENT_TYPE_URL, RECIPIENT_TYPE_TELEPHONE, ListCount
 from issuer.permissions import IsEditor
 from issuer.utils import generate_sha256_hashstring, request_authenticated_with_server_admin_token
 from mainsite.drf_fields import ValidImageField
@@ -704,3 +705,13 @@ class BadgeInstanceSerializerV2(DetailSerializerV2, OriginalJsonSerializerMixin)
             data['issuer'] = data['badgeclass'].issuer
 
         return data
+
+
+class ListCountSerializerV2(DetailSerializerV2, OriginalJsonSerializerMixin):
+    count = serializers.IntegerField(min_value=0, required=True, allow_null=False)
+
+    def __init__(self, count=0):
+        super().__init__()
+        self.count = count
+        self.instance = ListCount()
+        self.instance.count = count

--- a/apps/issuer/v2_api_urls.py
+++ b/apps/issuer/v2_api_urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from issuer.api import (IssuerList, IssuerDetail, IssuerBadgeClassList, BadgeClassDetail, BadgeInstanceList,
                         BadgeInstanceDetail, IssuerBadgeInstanceList, AllBadgeClassesList, BatchAssertionsIssue,
                         BatchAssertionsRevoke, IssuerTokensList, AssertionsChangedSince, BadgeClassesChangedSince,
-                        IssuersChangedSince)
+                        IssuersChangedSince, BadgeInstanceListCount, IssuerBadgeInstanceListCount)
 
 urlpatterns = [
 
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^issuers/changed$', IssuersChangedSince.as_view(), name='v2_api_issuers_changed_list'),
     url(r'^issuers/(?P<entity_id>[^/]+)$', IssuerDetail.as_view(), name='v2_api_issuer_detail'),
     url(r'^issuers/(?P<entity_id>[^/]+)/assertions$', IssuerBadgeInstanceList.as_view(), name='v2_api_issuer_assertion_list'),
+    url(r'^issuers/(?P<entity_id>[^/]+)/assertionscount$', IssuerBadgeInstanceListCount.as_view(), name='v2_api_issuer_assertion_list_count'),
     url(r'^issuers/(?P<entity_id>[^/]+)/badgeclasses$', IssuerBadgeClassList.as_view(), name='v2_api_issuer_badgeclass_list'),
 
     url(r'^badgeclasses$', AllBadgeClassesList.as_view(), name='v2_api_badgeclass_list'),
@@ -18,6 +19,7 @@ urlpatterns = [
     url(r'^badgeclasses/(?P<entity_id>[^/]+)$', BadgeClassDetail.as_view(), name='v2_api_badgeclass_detail'),
     url(r'^badgeclasses/(?P<entity_id>[^/]+)/issue$', BatchAssertionsIssue.as_view(), name='v2_api_badgeclass_issue'),
     url(r'^badgeclasses/(?P<entity_id>[^/]+)/assertions$', BadgeInstanceList.as_view(), name='v2_api_badgeclass_assertion_list'),
+    url(r'^badgeclasses/(?P<entity_id>[^/]+)/assertionscount$', BadgeInstanceListCount.as_view(), name='v2_api_badgeclass_assertion_list_count'),
 
     url(r'^assertions/revoke$', BatchAssertionsRevoke.as_view(), name='v2_api_assertion_revoke'),
     url(r'^assertions/changed$', AssertionsChangedSince.as_view(), name='v2_api_assertions_changed_list'),

--- a/apps/mainsite/pagination.py
+++ b/apps/mainsite/pagination.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from rest_framework.pagination import CursorPagination
+from rest_framework.pagination import CursorPagination, PageNumberPagination
 
 
 class BadgrCursorPagination(CursorPagination):
@@ -29,4 +29,29 @@ class BadgrCursorPagination(CursorPagination):
             ('nextResults', self.get_next_link() if self.has_next else None),
             ('hasPrevious', self.has_previous),
             ('previousResults', self.get_previous_link() if self.has_previous else None),
+        ])
+
+
+class BadgrPageNumberPagination(PageNumberPagination):
+
+    def __init__(self, page_size=None):
+        if page_size is not None:
+            self.page_size = page_size
+        super(BadgrPageNumberPagination, self).__init__()
+
+    def get_link_header(self):
+        links = []
+        if self.page.has_next:
+            links.append('<{}>; rel="next"'.format(self.get_next_link()))
+        if self.page.has_previous:
+            links.append('<{}>; rel="prev"'.format(self.get_previous_link()))
+        if len(links):
+            return ', '.join(links)
+
+    def get_page_info(self):
+        return OrderedDict([
+            ('hasNext', self.page.has_next),
+            ('nextResults', self.get_next_link() if self.page.has_next else None),
+            ('hasPrevious', self.has_previous),
+            ('previousResults', self.get_previous_link() if self.page.has_previous else None),
         ])


### PR DESCRIPTION
This PR is going to add PageNumberPagination on entities and particularly useful filtering, sorting and counting URLs for Assertions for a single BadgeClass and for a single Issuer