### PR TITLE
Remove pinned version of httplib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -100,6 +100,3 @@ django-ses==0.8.12
 
 pysaml2==5.3.0
 xmlsec==1.3.3
-
-# Temporarily pin httplib2 version for build issue. Remove once we can support latest version of setuptools
-httplib2==0.17.3


### PR DESCRIPTION
We had pinned a version of httplib2 where the newer one wasn't installable with the version of setuptools we were stuck on. We are no longer stuck on that version of setuptools, we can use the default version of httplib2.