### PR TITLE
Add PKCE support to OAuth API to support Badge Connect

### DIFF
--- a/apps/mainsite/oauth2_api.py
+++ b/apps/mainsite/oauth2_api.py
@@ -79,7 +79,7 @@ class AuthorizationApiView(OAuthLibMixin, APIView):
             if serializer.data.get('scopes'):
                 scopes = ' '.join(serializer.data.get("scopes"))
             else:
-                scops = serializer.data.get('scope')
+                scopes = serializer.data.get('scope')
             allow = serializer.data.get("allow")
 
             success_url = self.get_authorization_redirect_url(scopes, credentials, allow)


### PR DESCRIPTION
Add PKCE support to our OAuth process on the API side. Needs UI work to complete (picking up a code_challenge and code_challenge_method query parameters and passing them to the API.

Corrects key error in registration serializer from `client_id_expires_at` to `client_secret_expires_at`