### PR TITLE
Fix for docker containers failing to build due to missing packages

### DIFF
--- a/.docker/Dockerfile.dev.api
+++ b/.docker/Dockerfile.dev.api
@@ -8,7 +8,9 @@ RUN apt-get install -y default-libmysqlclient-dev \
                        python3-dev \
                        python3-cairo \
                        build-essential \
-                       xmlsec1
+                       xmlsec1 \
+                       libxmlsec1-dev \
+                       pkg-config
 
 RUN pip install uwsgi
 

--- a/.docker/Dockerfile.prod.api
+++ b/.docker/Dockerfile.prod.api
@@ -8,7 +8,9 @@ RUN apt-get install -y default-libmysqlclient-dev \
                        python3-dev \
                        python3-cairo \
                        build-essential \
-                       xmlsec1
+                       xmlsec1 \
+                       libxmlsec1-dev \
+                       pkg-config
 
 COPY requirements.txt                   /badgr_server
 COPY manage.py                          /badgr_server


### PR DESCRIPTION
Running docker-compose up on either docker file results in an error when building the xmlsec wheel: 
`Could not find xmlsec1 config. Are libxmlsec1-dev and pkg-config installed?` 