### PR TITLE
Ensure key objects do not get deleted if their created_by user is deleted

### DIFF
--- a/apps/backpack/models.py
+++ b/apps/backpack/models.py
@@ -1,19 +1,17 @@
 # encoding: utf-8
 
-
 import os
 import binascii
 from collections import OrderedDict
 
 import cachemodel
 from basic_models.models import CreatedUpdatedAt
-from django.conf import settings
 from django.urls import reverse
 from django.db import models, transaction
 from django.db.models import Q
 
 from entity.models import BaseVersionedEntity
-from issuer.models import BaseAuditedModel, BadgeInstance
+from issuer.models import BaseAuditedModelDeletedWithUser, BadgeInstance
 from backpack.sharing import SharingManager
 from issuer.utils import CURRENT_OBI_VERSION, get_obi_context, add_obi_version_ifneeded
 from mainsite.managers import SlugOrJsonIdCacheModelManager
@@ -21,7 +19,7 @@ from mainsite.models import BadgrApp
 from mainsite.utils import OriginSetting
 
 
-class BackpackCollection(BaseAuditedModel, BaseVersionedEntity):
+class BackpackCollection(BaseAuditedModelDeletedWithUser, BaseVersionedEntity):
     entity_class_name = 'BackpackCollection'
     name = models.CharField(max_length=128)
     description = models.CharField(max_length=255, blank=True)

--- a/apps/badgeuser/models.py
+++ b/apps/badgeuser/models.py
@@ -22,7 +22,7 @@ from rest_framework.authtoken.models import Token
 from backpack.models import BackpackCollection
 from badgeuser.tasks import process_post_recipient_id_deletion, process_post_recipient_id_verification_change
 from entity.models import BaseVersionedEntity
-from issuer.models import Issuer, BadgeInstance, BaseAuditedModel
+from issuer.models import Issuer, BadgeInstance, BaseAuditedModel, BaseAuditedModelDeletedWithUser
 from badgeuser.managers import CachedEmailAddressManager, BadgeUserManager
 from badgeuser.utils import generate_badgr_username
 from mainsite.models import ApplicationInfo
@@ -546,7 +546,7 @@ class TermsVersion(IsActive, BaseAuditedModel, cachemodel.CacheModel):
         TermsVersion.cached.publish_latest()
 
 
-class TermsAgreement(BaseAuditedModel, cachemodel.CacheModel):
+class TermsAgreement(BaseAuditedModelDeletedWithUser, cachemodel.CacheModel):
     user = models.ForeignKey('badgeuser.BadgeUser',
                              on_delete=models.CASCADE)
     terms_version = models.PositiveIntegerField()

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -52,6 +52,23 @@ logger = badgrlog.BadgrLogger()
 class BaseAuditedModel(cachemodel.CacheModel):
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
     created_by = models.ForeignKey('badgeuser.BadgeUser', blank=True, null=True, related_name="+",
+                                   on_delete=models.SET_NULL)
+    updated_at = models.DateTimeField(auto_now=True, db_index=True)
+    updated_by = models.ForeignKey('badgeuser.BadgeUser', blank=True, null=True, related_name="+",
+                                   on_delete=models.SET_NULL)
+
+    class Meta:
+        abstract = True
+
+    @property
+    def cached_creator(self):
+        from badgeuser.models import BadgeUser
+        return BadgeUser.cached.get(id=self.created_by_id)
+
+
+class BaseAuditedModelDeletedWithUser(cachemodel.CacheModel):
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    created_by = models.ForeignKey('badgeuser.BadgeUser', blank=True, null=True, related_name="+",
                                    on_delete=models.CASCADE)
     updated_at = models.DateTimeField(auto_now=True, db_index=True)
     updated_by = models.ForeignKey('badgeuser.BadgeUser', blank=True, null=True, related_name="+",


### PR DESCRIPTION
Sometimes system admins have need to delete a BadgeUser, typically because content on this user is to be merged with another.

Backpack Collections are deleted
Issuers should not be deleted