### PR TITLE
BP-3305

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -477,9 +477,9 @@ class BadgeClass(ResizeUploadedImage,
     def __init__(self, *args, **kwargs):
         super(BadgeClass, self).__init__(*args, **kwargs)
         if self.id is not None:
-            self.__original_image_hash = self._hash_for_image
+            self.original_image_hash = self.hash_for_image
         else:
-            self.__original_image_hash = None
+            self.original_image_hash = None
 
     def publish(self):
         fields_cache = self._state.fields_cache  # stash the fields cache to avoid publishing related objects here
@@ -509,20 +509,14 @@ class BadgeClass(ResizeUploadedImage,
 
     def save(self, force_resize=False, *args, **kwargs):
         super(BadgeClass, self).save(force_resize, *args, **kwargs)
-        updated_image_hash = self._hash_for_image #assign local cause we need this twice
-        if self.__original_image_hash != updated_image_hash:
-            if self.__original_image_hash is not None:
-                logger.logger.info("Rebaking assertions for badge {}".format(self.entity_id))
-                from issuer.tasks import rebake_all_assertions_for_badge_class
-                batch_size = getattr(settings, 'BADGE_ASSERTION_AUTO_REBAKE_BATCH_SIZE', 1000)
-                rebake_all_assertions_for_badge_class.delay(self, limit=batch_size, replay=True)
-            self.__original_image_hash = updated_image_hash
+        from issuer.tasks import evaluate_badgeclass_image_update
+        evaluate_badgeclass_image_update.delay(self)
 
     def get_absolute_url(self):
         return reverse('badgeclass_json', kwargs={'entity_id': self.entity_id})
 
     @property
-    def _hash_for_image(self):
+    def hash_for_image(self):
         # from https://nitratine.net/blog/post/how-to-hash-files-in-python/
         try:
             block_size = 65536


### PR DESCRIPTION
- changing the image rebake check to be a async task so that the save method returns without having to make a file read (potentially via network)