### PR TITLE
 Allow to post path strings to an existing image in image fields

### DIFF
--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -495,3 +495,7 @@ AUTHCODE_EXPIRES_SECONDS = 600  # needs to be long enough to fetch information f
 SAML_EMAIL_KEYS = ['Email', 'mail', 'emailaddress', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']
 SAML_FIRST_NAME_KEYS = ['FirstName', 'givenName', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname']
 SAML_LAST_NAME_KEYS = ['LastName', 'sn', 'surname', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname']
+
+# Allow to send path to an existing image in image fields
+# For eg file:///uploads/issuer/xyz.png will point to MEDIA_ROOT/uploads/issuer/xyz.png
+ALLOW_IMAGE_PATHS = False


### PR DESCRIPTION
Fedora Badges keeps a separate repo of badge images. It would make the migration a lot easier if badgr could accept path strings to existing images so we can mount our repo in the MEDIA_ROOT and point to those images.

The paths can be sent in the following **format**: `file:///uploads/issuer/xyz.png`
The above will point to: `MEDIA_ROOT/uploads/issuer/xyz.png`

Any path that point's outside the media folder will fail. This can be enabled by **ALLOW_IMAGE_PATHS = True** in settings.

If this PR is acceptable let me know so I can write tests for it. Further if there is a better way to do this I would like to know.