### PR TITLE
BP-3542. Add 'email' lowercase to SAML_EMAIL_KEYS

### DIFF
--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -492,6 +492,6 @@ AUTHCODE_SECRET_KEY = Fernet.generate_key()
 AUTHCODE_EXPIRES_SECONDS = 600  # needs to be long enough to fetch information from socialauth providers
 
 # SAML Settings
-SAML_EMAIL_KEYS = ['Email', 'mail', 'emailaddress', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']
+SAML_EMAIL_KEYS = ['Email', 'email', 'mail', 'emailaddress', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']
 SAML_FIRST_NAME_KEYS = ['FirstName', 'givenName', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname']
 SAML_LAST_NAME_KEYS = ['LastName', 'sn', 'surname', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname']


### PR DESCRIPTION
A client IDP needs "email" lowercase as a claim in the SAML assertion.