### PR TITLE
Simplify tests for detecting presence of image open graph content for bots

### DIFF
--- a/apps/issuer/tests/test_public.py
+++ b/apps/issuer/tests/test_public.py
@@ -164,10 +164,7 @@ class PublicAPITests(SetupIssuerHelper, BadgrTestCase):
             with self.assertNumQueries(0):
                 response = self.client.get(test_collection.share_url, **headers)
                 self.assertEqual(response.status_code, 200)
-                self.assertNotContains(response, '<meta property="og:image"', html=True)
-                self.assertNotContains(response, '<meta property="og:image:secure_url"', html=True)
-                self.assertNotContains(response, '<meta property="og:image:width"', html=True)
-                self.assertNotContains(response, '<meta property="og:image:height"', html=True)
+                self.assertNotContains(response, 'og:image', html=True)
                 self.assertNotContains(response, '<img src="">', html=True)
 
     def test_public_collection_json(self):


### PR DESCRIPTION
In the bot template, ensure images are not present for shared empty collections.