### PR TITLE
Ensure query parameters are passed all the way back to UI on SAML fail

### DIFF
--- a/apps/badgrsocialauth/tests/test_saml2.py
+++ b/apps/badgrsocialauth/tests/test_saml2.py
@@ -225,6 +225,9 @@ class SAML2Tests(BadgrTestCase):
         self.assertIn(self.config.slug, resp.url)
         self.assertEqual(saml_account_count, Saml2Account.objects.count(), "A Saml2Account must not have been created.")
 
+        resp = self.client.get(resp.url)
+        self.assertIn(self.config.slug, resp.url, "Query params are included in the response all the way back to the UI")
+
     def test_add_samlaccount_to_existing_user(self):
         # email exists, but is verified
         email = 'exampleuser@example.com'

--- a/apps/badgrsocialauth/views.py
+++ b/apps/badgrsocialauth/views.py
@@ -312,7 +312,7 @@ class SamlFailureRedirect(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         badgr_app = BadgrApp.objects.get_current(self.request)
         if badgr_app is not None:
-            return set_url_query_params(badgr_app.ui_signup_failure_redirect, **kwargs)
+            return set_url_query_params(badgr_app.ui_signup_failure_redirect, **self.request.GET)
 
 
 class SamlEmailExistsRedirect(RedirectView):


### PR DESCRIPTION
Ensure query parameters are passed all the way back to UI on SAML failure cases.

