### PR TITLE
Bugfix/url as identifier for staff manipulation bg 3822

### DIFF
--- a/apps/badgrsocialauth/tests/test_saml2.py
+++ b/apps/badgrsocialauth/tests/test_saml2.py
@@ -221,7 +221,7 @@ class SAML2Tests(BadgrTestCase):
         self.assertEqual(resp.status_code, 302)
         resp = self.client.get(resp.url)
         self.assertEqual(resp.status_code, 302)
-        self.assertIn("authError", resp.url)
+        self.assertIn("authError=Could+not", resp.url)
         self.assertIn(self.config.slug, resp.url)
         self.assertEqual(saml_account_count, Saml2Account.objects.count(), "A Saml2Account must not have been created.")
 

--- a/apps/badgrsocialauth/views.py
+++ b/apps/badgrsocialauth/views.py
@@ -312,7 +312,8 @@ class SamlFailureRedirect(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         badgr_app = BadgrApp.objects.get_current(self.request)
         if badgr_app is not None:
-            return set_url_query_params(badgr_app.ui_signup_failure_redirect, **self.request.GET)
+            params = {k: self.request.GET.get(k) for k in self.request.GET.keys()}
+            return set_url_query_params(badgr_app.ui_signup_failure_redirect, **params)
 
 
 class SamlEmailExistsRedirect(RedirectView):
@@ -335,7 +336,7 @@ class SamlEmailExistsRedirect(RedirectView):
         existing_email = CachedEmailAddress.cached.get(email=decoded_email)
         token = accesstoken_for_authcode(authcode)
         if token is not None and not token.is_expired() and token.user == existing_email.user:
-            saml2_account = Saml2Account.objects.create(config=config, user=existing_email.user, uuid=email)
+            saml2_account = Saml2Account.objects.create(config=config, user=existing_email.user, uuid=decoded_email)
             return redirect_user_to_login(saml2_account.user)
         elif token is not None and token.is_expired():
             return saml2_fail(

--- a/apps/issuer/api_v1.py
+++ b/apps/issuer/api_v1.py
@@ -139,6 +139,11 @@ class IssuerStaffList(VersionedObjectMixin, APIView):
               paramType: form
               description: A verified user recipient identifier of the user whose role will be added, removed or modified. Must be of type url.
               required: false
+            - name: telephone
+              type: string
+              paramType: form
+              description: A verified user recipient identifier of the user whose role will be added, removed or modified. Must be of type telephone.
+              required: false
             - name: role
               type: string
               paramType: form
@@ -175,7 +180,7 @@ class IssuerStaffList(VersionedObjectMixin, APIView):
         except (get_user_model().DoesNotExist, CachedEmailAddress.DoesNotExist, UserRecipientIdentifier.DoesNotExist):
             error_text = "User not found. Email must correspond to an existing user."
             if user_id is None:
-                error_text = 'User not found. Neither email address, username, or url was provided.'
+                error_text = 'User not found. please provide a valid email address, username, url or telephone identifier.'
             return Response(
                 error_text, status=status.HTTP_404_NOT_FOUND
             )

--- a/apps/issuer/api_v1.py
+++ b/apps/issuer/api_v1.py
@@ -163,6 +163,11 @@ class IssuerStaffList(VersionedObjectMixin, APIView):
                 user_to_modify = UserRecipientIdentifier.objects.get(
                     identifier=user_id, verified=True
                 ).user
+            elif serializer.validated_data.get('telephone'):
+                user_id = serializer.validated_data.get('telephone')
+                user_to_modify = UserRecipientIdentifier.objects.get(
+                    identifier=user_id, verified=True
+                ).user
             else:
                 user_id = serializer.validated_data.get('email')
                 user_to_modify = CachedEmailAddress.objects.get(

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -125,9 +125,10 @@ class IssuerRoleActionSerializerV1(serializers.Serializer):
         validators=[ChoicesValidator(list(dict(IssuerStaff.ROLE_CHOICES).keys()))],
         default=IssuerStaff.ROLE_STAFF)
     url = serializers.URLField(max_length=1024, required=False)
+    telephone = serializers.CharField(max_length=100, required=False)
 
     def validate(self, attrs):
-        identifiers = [attrs.get('username'), attrs.get('email'), attrs.get('url')]
+        identifiers = [attrs.get('username'), attrs.get('email'), attrs.get('url'), attrs.get('telephone')]
         identifier_count = len(list(filter(None.__ne__, identifiers)))
         if identifier_count > 1:
             raise serializers.ValidationError(

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -132,7 +132,7 @@ class IssuerRoleActionSerializerV1(serializers.Serializer):
         identifier_count = len(list(filter(None.__ne__, identifiers)))
         if identifier_count > 1:
             raise serializers.ValidationError(
-                'Please provided only one of the following: a username, email address, or a user recipient identifier of type url.'
+                'Please provided only one of the following: a username, email address, url, or telephone recipient identifier.'
             )
         return attrs
 

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -124,11 +124,15 @@ class IssuerRoleActionSerializerV1(serializers.Serializer):
     role = serializers.CharField(
         validators=[ChoicesValidator(list(dict(IssuerStaff.ROLE_CHOICES).keys()))],
         default=IssuerStaff.ROLE_STAFF)
+    url = serializers.URLField(max_length=1024, required=False)
 
     def validate(self, attrs):
-        if attrs.get('username') and attrs.get('email'):
+        identifiers = [attrs.get('username'), attrs.get('email'), attrs.get('url')]
+        identifier_count = len(list(filter(None.__ne__, identifiers)))
+        if identifier_count > 1:
             raise serializers.ValidationError(
-                'Either a username or email address must be provided, not both.')
+                'Please provided only one of the following: a username, email address, or a user recipient identifier of type url.'
+            )
         return attrs
 
 

--- a/apps/issuer/tests/test_issuer.py
+++ b/apps/issuer/tests/test_issuer.py
@@ -392,6 +392,75 @@ class IssuerTests(SetupOAuth2ApplicationHelper, SetupIssuerHelper, BadgrTestCase
         staff = test_issuer.staff.all()
         self.assertEqual(test_issuer.editors.count(), 2)
 
+    def test_modify_the_staff_role_of_a_user_by_url_recipient_identifier(self):
+        owner = self.setup_user(authenticate=True)
+        test_issuer = self.setup_issuer(owner=owner)
+        self.assertEqual(test_issuer.staff.count(), 1)
+
+        # Create a user who has only a url identifier:
+        recipient_url = "http://example.com"
+        user = self.setup_user(first_name='user_first', last_name='user_last',)
+        UserRecipientIdentifier.objects.create(identifier=recipient_url, user=user, verified=True)
+        IssuerStaff.objects.get_or_create(user=user, issuer=test_issuer, defaults={'role': IssuerStaff.ROLE_STAFF})
+
+        # Attempting to modify the staff role of a user with good recipient identifier succeeds
+        response = self.client.post('/v1/issuer/issuers/{slug}/staff'.format(slug=test_issuer.entity_id), {
+            'action': 'modify',
+            'url': recipient_url,
+            'role': IssuerStaff.ROLE_EDITOR
+        })
+        self.assertEqual(response.status_code, 200)
+
+        # Attempting to modify the staff role of a user with bad recipient identifier fails
+        second_response = self.client.post('/v1/issuer/issuers/{slug}/staff'.format(slug=test_issuer.entity_id), {
+            'action': 'modify',
+            'url': "http://badIdentifier.com",
+            'role': IssuerStaff.ROLE_EDITOR
+        })
+        self.assertEqual(second_response.status_code, 404)
+
+        # Attempting to modify the staff role of an unverified user fails
+        user_unverified = UserRecipientIdentifier.objects.get(user_id=user.id)
+        user_unverified.verified = False
+        user_unverified.save()
+        unverified_response = self.client.post('/v1/issuer/issuers/{slug}/staff'.format(slug=test_issuer.entity_id), {
+            'action': 'modify',
+            'url': recipient_url,
+            'role': IssuerStaff.ROLE_EDITOR
+        })
+        self.assertEqual(unverified_response.status_code, 404)
+
+
+    def test_add_a_user_staff_role_by_url_recipient_identifier(self):
+        owner = self.setup_user(authenticate=True)
+        test_issuer = self.setup_issuer(owner=owner)
+        self.assertEqual(test_issuer.staff.count(), 1)
+
+        recipient_url = "http://example.com"
+        user = self.setup_user(first_name='user_first', last_name='user_last',)
+        UserRecipientIdentifier.objects.create(identifier=recipient_url, user=user, verified=True)
+
+        # Attempting to add the staff role of an unverified user fails
+        response = self.client.post('/v1/issuer/issuers/{slug}/staff'.format(slug=test_issuer.entity_id), {
+            'action': 'add',
+            'url': recipient_url,
+            'role': IssuerStaff.ROLE_EDITOR
+        })
+        self.assertEqual(response.status_code, 200)
+
+        # Attempting to add a staff user role with who is not verified fails
+        recipient_url = "http://example2.com"
+        user_unverified = self.setup_user(first_name='user_unverified_first', last_name='user_unverified_last',)
+        UserRecipientIdentifier.objects.create(identifier=recipient_url, user=user_unverified, verified=False)
+
+        unverified_response = self.client.post('/v1/issuer/issuers/{slug}/staff'.format(slug=test_issuer.entity_id), {
+            'action': 'modify',
+            'url': recipient_url,
+            'role': IssuerStaff.ROLE_EDITOR
+        })
+        self.assertEqual(unverified_response.status_code, 404)
+
+
     def test_cannot_modify_or_remove_self(self):
         """
         The authenticated issuer owner cannot modify their own role or remove themself from the list.

--- a/apps/mainsite/version.py
+++ b/apps/mainsite/version.py
@@ -1,1 +1,1 @@
-VERSION = (3, 7, 1)
+VERSION = (3, 7, 4)


### PR DESCRIPTION
badgr server changes to support add/mod/del of staff roles using a url as an identifier.