### PR TITLE
Trigger assertion save on async rebake

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -925,7 +925,7 @@ class BadgeInstance(BaseAuditedModel,
             output_file=new_image
         )
 
-        new_filename = generate_rebaked_filename(self.image.name)
+        new_filename = generate_rebaked_filename(self.image.name, self.cached_badgeclass.image.name)
         new_name = default_storage.save(new_filename, ContentFile(new_image.read()))
         default_storage.delete(self.image.name)
         self.image.name = new_name

--- a/apps/issuer/tasks.py
+++ b/apps/issuer/tasks.py
@@ -121,7 +121,7 @@ def rebake_assertion_image(self, assertion_entity_id=None, obi_version=CURRENT_O
             'error': "Skipping imported assertion={}  source_url={}".format(assertion_entity_id, assertion.source_url)
         }
 
-    assertion.rebake(obi_version=obi_version)
+    assertion.rebake(obi_version=obi_version, save=True)
 
     return {
         'success': True

--- a/apps/issuer/tasks.py
+++ b/apps/issuer/tasks.py
@@ -100,7 +100,7 @@ def rebake_all_assertions_for_badge_class(self, badge_class_id, obi_version=CURR
         'count': count,
         'limit': limit,
         'offset': offset,
-        'message': "Enqueued {} assertions for rebaking".format(count)
+        'message': "Enqueued {} assertions for rebaking due to badge class change".format(count)
     }
 
 
@@ -121,10 +121,11 @@ def rebake_assertion_image(self, assertion_entity_id=None, obi_version=CURRENT_O
             'error': "Skipping imported assertion={}  source_url={}".format(assertion_entity_id, assertion.source_url)
         }
 
-    assertion.rebake(obi_version=obi_version) #, save=True)
+    assertion.rebake(obi_version=obi_version)
 
     return {
-        'success': True
+        'success': True,
+        'message': "Rebaked image for {}".format(assertion_entity_id)
     }
 
 

--- a/apps/issuer/tasks.py
+++ b/apps/issuer/tasks.py
@@ -121,7 +121,7 @@ def rebake_assertion_image(self, assertion_entity_id=None, obi_version=CURRENT_O
             'error': "Skipping imported assertion={}  source_url={}".format(assertion_entity_id, assertion.source_url)
         }
 
-    assertion.rebake(obi_version=obi_version, save=True)
+    assertion.rebake(obi_version=obi_version) #, save=True)
 
     return {
         'success': True

--- a/apps/issuer/tests/test_assertion.py
+++ b/apps/issuer/tests/test_assertion.py
@@ -149,6 +149,9 @@ class AssertionTests(SetupIssuerHelper, BadgrTestCase):
         test_assertion_v1 = test_badgeclass_v1.issue(recipient_id='test1@email.test')
         test_assertion_v2 = test_badgeclass_v2.issue(recipient_id='test2@email.test')
         test_assertion_v2_2 = test_badgeclass_v2.issue(recipient_id='test3@email.test')
+        self.assertEqual(test_assertion_v1.image.name.split(".").pop(), 'png')
+        self.assertEqual(test_assertion_v2.image.name.split(".").pop(), 'png')
+        self.assertEqual(test_assertion_v2_2.image.name.split(".").pop(), 'png')
 
         with open(self.get_test_svg_image_path(), 'rb') as image_update:
             # v1 api
@@ -170,6 +173,7 @@ class AssertionTests(SetupIssuerHelper, BadgrTestCase):
             self.assertNotEqual('', updated_image_hash_v1)
             self.assertNotEqual(updated_image_hash_v1, original_image_hash_v1)
             self.assertGreater(updated_assertion_v1.updated_at, test_assertion_v1.updated_at)
+            self.assertEqual(updated_assertion_v1.image.name.split(".").pop(), 'svg')
 
         with open(self.get_test_svg_image_path(), 'rb') as image_update:
             # v2 api
@@ -191,12 +195,14 @@ class AssertionTests(SetupIssuerHelper, BadgrTestCase):
             self.assertNotEqual('', updated_image_hash_v2)
             self.assertNotEqual(updated_image_hash_v2, original_image_hash_v2)
             self.assertGreater(updated_assertion_v2.updated_at, test_assertion_v2.updated_at)
+            self.assertEqual(updated_assertion_v2.image.name.split(".").pop(), 'svg')
             # test batching works in task
             updated_assertion_v2_2 = BadgeInstance.objects.get(entity_id=test_assertion_v2_2.entity_id)
             updated_image_hash_v2_2 = hash_for_image(updated_assertion_v2_2.image)
             self.assertNotEqual('', updated_image_hash_v2_2)
             self.assertNotEqual(updated_image_hash_v2_2, original_image_hash_v2_2)
             self.assertGreater(updated_assertion_v2_2.updated_at, test_assertion_v2_2.updated_at)
+            self.assertEqual(updated_assertion_v2_2.image.name.split(".").pop(), 'svg')
 
     def test_updating_badgeclass_non_image_does_not_rebake_assertions(self):
         test_user = self.setup_user(authenticate=True)

--- a/apps/issuer/tests/test_assertion.py
+++ b/apps/issuer/tests/test_assertion.py
@@ -169,6 +169,7 @@ class AssertionTests(SetupIssuerHelper, BadgrTestCase):
             updated_image_hash_v1 = hash_for_image(updated_assertion_v1.image)
             self.assertNotEqual('', updated_image_hash_v1)
             self.assertNotEqual(updated_image_hash_v1, original_image_hash_v1)
+            self.assertGreater(updated_assertion_v1.updated_at, test_assertion_v1.updated_at)
 
         with open(self.get_test_svg_image_path(), 'rb') as image_update:
             # v2 api
@@ -189,11 +190,13 @@ class AssertionTests(SetupIssuerHelper, BadgrTestCase):
             updated_image_hash_v2 = hash_for_image(updated_assertion_v2.image)
             self.assertNotEqual('', updated_image_hash_v2)
             self.assertNotEqual(updated_image_hash_v2, original_image_hash_v2)
+            self.assertGreater(updated_assertion_v2.updated_at, test_assertion_v2.updated_at)
             # test batching works in task
             updated_assertion_v2_2 = BadgeInstance.objects.get(entity_id=test_assertion_v2_2.entity_id)
             updated_image_hash_v2_2 = hash_for_image(updated_assertion_v2_2.image)
             self.assertNotEqual('', updated_image_hash_v2_2)
             self.assertNotEqual(updated_image_hash_v2_2, original_image_hash_v2_2)
+            self.assertGreater(updated_assertion_v2_2.updated_at, test_assertion_v2_2.updated_at)
 
     def test_updating_badgeclass_non_image_does_not_rebake_assertions(self):
         test_user = self.setup_user(authenticate=True)

--- a/apps/issuer/utils.py
+++ b/apps/issuer/utils.py
@@ -51,9 +51,10 @@ def generate_md5_hashstring(identifier, salt=None):
     return 'md5$' + hashlib.md5(key.encode('utf-8')).hexdigest()
 
 
-def generate_rebaked_filename(oldname):
+def generate_rebaked_filename(oldname, badgeclass_filename):
     parts = oldname.split('.')
-    ext = parts.pop()
+    badgeclass_filename_parts = badgeclass_filename.split('.')
+    ext = badgeclass_filename_parts.pop()
     parts.append('rebaked')
     return 'assertion-{}.{}'.format(hashlib.md5(''.join(parts).encode('utf-8')).hexdigest(), ext)
 


### PR DESCRIPTION
When the rebake task runs, make sure to update the assertions' updated_at field.