### PR TITLE
Search for BadgrApp by pk the way it is published by default on save()

### DIFF
--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -988,12 +988,7 @@ class BadgeInstance(BaseAuditedModel,
 
     def notify_earner(self, badgr_app=None, renotify=False):
         """
-        Sends an email notification to the badge earner.
-        This process involves creating a badgeanalysis.models.OpenBadge
-        returns the EarnerNotification instance.
-
-        TODO: consider making this an option on initial save and having a foreign key to
-        the notification model instance (which would link through to the OpenBadge)
+        Sends an email notification to the badge recipient.
         """
         if self.recipient_type != RECIPIENT_TYPE_EMAIL:
             return

--- a/apps/mainsite/models.py
+++ b/apps/mainsite/models.py
@@ -100,7 +100,7 @@ class BadgrAppManager(cachemodel.CacheModelManager):
     def get_by_id_or_default(self, badgrapp_id=None):
         if badgrapp_id:
             try:
-                return self.get(id=badgrapp_id)
+                return self.get(pk=badgrapp_id)
             except (self.model.DoesNotExist, ValueError,):
                 pass
         try:
@@ -110,7 +110,7 @@ class BadgrAppManager(cachemodel.CacheModelManager):
             legacy_default_setting = getattr(settings, 'BADGR_APP_ID', None)
             if legacy_default_setting is not None:
                 try:
-                    badgrapp = self.get(id=legacy_default_setting)
+                    badgrapp = self.get(pk=legacy_default_setting)
                 except self.model.DoesNotExist:
                     pass
             else:


### PR DESCRIPTION
In the code previously, the get_by_id_or_default() manager method was using the field "id" to generate the cache key. Switching to "pk" uses the cache entry that is automatically created by the CacheModel.publish() method by default that is auto-updated every time the model is saved.