### PR TITLE
Improve performance of awarding assertions

### DIFF
--- a/apps/issuer/admin.py
+++ b/apps/issuer/admin.py
@@ -93,7 +93,7 @@ class BadgeClassExtensionInline(TabularInline):
 
 class BadgeClassAdmin(DjangoObjectActions, ModelAdmin):
     readonly_fields = ('created_by', 'created_at', 'updated_at', 'old_json', 'source', 'source_url', 'entity_id', 'slug')
-    list_display = ('badge_image', 'name', 'entity_id', 'issuer_link', 'recipient_count')
+    list_display = ('badge_image', 'name', 'entity_id', 'issuer_link')
     list_display_links = ('badge_image', 'name',)
     list_filter = ('created_at',)
     search_fields = ('name', 'entity_id', 'issuer__name',)

--- a/apps/issuer/api.py
+++ b/apps/issuer/api.py
@@ -248,7 +248,7 @@ class BadgeClassDetail(BaseEntityDetailView):
         response = super(BadgeClassDetail, self).put(request, **kwargs)
         if response.status_code == 200 and getattr(settings, 'BADGERANK_NOTIFY_ON_FIRST_ASSERTION', True):
             badgeclass = self.get_object(request, **kwargs)
-            if badgeclass.recipient_count() > 0:
+            if badgeclass.has_nonrevoked_assertions():
                 from issuer.tasks import notify_badgerank_of_badgeclass
                 notify_badgerank_of_badgeclass.delay(badgeclass_pk=badgeclass.pk)
         return response

--- a/apps/issuer/cache_keys.py
+++ b/apps/issuer/cache_keys.py
@@ -1,0 +1,2 @@
+def recipient_count(pk):
+    return "badgeclass_recipient_count_%s" % pk

--- a/apps/issuer/cache_keys.py
+++ b/apps/issuer/cache_keys.py
@@ -1,2 +1,0 @@
-def recipient_count(pk):
-    return "badgeclass_recipient_count_%s" % pk

--- a/apps/issuer/managers.py
+++ b/apps/issuer/managers.py
@@ -324,6 +324,13 @@ class BadgeInstanceManager(BaseOpenBadgeObjectManager):
             **kwargs
         )
 
+        notify_badgerank = (
+           (
+                not getattr(settings, 'BADGERANK_NOTIFY_ON_BADGECLASS_CREATE', True) and
+                getattr(settings, 'BADGERANK_NOTIFY_ON_FIRST_ASSERTION', True)
+           ) and not badgeclass.has_nonrevoked_assertions()
+        )
+
         with transaction.atomic():
             new_instance.save()
 
@@ -355,9 +362,7 @@ class BadgeInstanceManager(BaseOpenBadgeObjectManager):
         if notify:
             new_instance.notify_earner(badgr_app=badgr_app)
 
-        if badgeclass.recipient_count() == 1 and (
-                not getattr(settings, 'BADGERANK_NOTIFY_ON_BADGECLASS_CREATE', True) and
-                getattr(settings, 'BADGERANK_NOTIFY_ON_FIRST_ASSERTION', True)):
+        if notify_badgerank:
             from issuer.tasks import notify_badgerank_of_badgeclass
             notify_badgerank_of_badgeclass.delay(badgeclass_pk=badgeclass.pk)
 

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -562,6 +562,13 @@ class BadgeClass(ResizeUploadedImage,
     def has_nonrevoked_assertions(self):
         return self.badgeinstances.filter(revoked=False).exists()
 
+    """
+    Included for legacy purposes. It is inefficient to routinely call this for badge classes with large numbers of assertions.
+    """
+    @property
+    def v1_api_recipient_count(self):
+        return self.badgeinstances.filter(revoked=False).count()
+
     def pathway_element_count(self):
         return len(self.cached_pathway_elements())
 

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -37,7 +37,6 @@ from mainsite.models import BadgrApp, EmailBlacklist
 from mainsite import blacklist
 from mainsite.utils import OriginSetting, generate_entity_uri
 
-from . import cache_keys
 from .utils import (add_obi_version_ifneeded, CURRENT_OBI_VERSION, generate_rebaked_filename,
                     generate_sha256_hashstring, get_obi_context, parse_original_datetime, UNVERSIONED_BAKED_VERSION)
 

--- a/apps/issuer/models.py
+++ b/apps/issuer/models.py
@@ -1007,7 +1007,7 @@ class BadgeInstance(BaseAuditedModel,
             pass
 
 
-def notify_earner(self, badgr_app=None, renotify=False):
+    def notify_earner(self, badgr_app=None, renotify=False):
         """
         Sends an email notification to the badge recipient.
         """

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -163,6 +163,7 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
     criteria = MarkdownCharField(allow_blank=True, required=False, write_only=True)
     criteria_text = MarkdownCharField(required=False, allow_null=True, allow_blank=True)
     criteria_url = StripTagsCharField(required=False, allow_blank=True, allow_null=True, validators=[URLValidator()])
+    recipient_count = serializers.IntegerField(required=False, read_only=True, source='v1_api_recipient_count')
     pathway_element_count = serializers.IntegerField(required=False, read_only=True)
     description = StripTagsCharField(max_length=16384, required=True, convert_null=True)
 

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -163,7 +163,6 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
     criteria = MarkdownCharField(allow_blank=True, required=False, write_only=True)
     criteria_text = MarkdownCharField(required=False, allow_null=True, allow_blank=True)
     criteria_url = StripTagsCharField(required=False, allow_blank=True, allow_null=True, validators=[URLValidator()])
-    recipient_count = serializers.IntegerField(required=False, read_only=True)
     pathway_element_count = serializers.IntegerField(required=False, read_only=True)
     description = StripTagsCharField(max_length=16384, required=True, convert_null=True)
 

--- a/apps/issuer/tests/test_assertion.py
+++ b/apps/issuer/tests/test_assertion.py
@@ -1075,7 +1075,7 @@ class AssertionTests(SetupIssuerHelper, BadgrTestCase):
         test_issuer = self.setup_issuer(owner=test_user)
         test_badgeclass = self.setup_badgeclass(issuer=test_issuer)
 
-        original_recipient_count = test_badgeclass.recipient_count()
+        original_recipient_count = test_badgeclass.badgeinstances.filter(revoked=False).count()
 
         new_assertion_props = {
             'email': 'test3@example.com',
@@ -1091,7 +1091,7 @@ class AssertionTests(SetupIssuerHelper, BadgrTestCase):
             badge=test_badgeclass.entity_id,
         ))
         badgeclass_data = response.data
-        self.assertEqual(badgeclass_data.get('recipient_count'), original_recipient_count+1)
+        self.assertEqual(test_badgeclass.badgeinstances.filter(revoked=False).count(), original_recipient_count+1)
 
     def test_batch_assertions_throws_400(self):
         test_user = self.setup_user(authenticate=True)


### PR DESCRIPTION
Use atomic increment/decrement cache methods instead of SQL queries to update `BadgeClass.recipient_count` upon assertion creation, revocation and deletion.