### PR TITLE
Fix serializer max lastName field length to database constraint of 150

### DIFF
--- a/apps/badgeuser/serializers_v2.py
+++ b/apps/badgeuser/serializers_v2.py
@@ -40,7 +40,7 @@ class BadgeUserEmailSerializerV2(DetailSerializerV2):
 
 class BadgeUserSerializerV2(DetailSerializerV2):
     firstName = StripTagsCharField(source='first_name', max_length=30, allow_blank=True)
-    lastName = StripTagsCharField(source='last_name', max_length=30, allow_blank=True)
+    lastName = StripTagsCharField(source='last_name', max_length=150, allow_blank=True)
     password = serializers.CharField(style={'input_type': 'password'}, write_only=True, required=False, validators=[PasswordValidator()])
     currentPassword = serializers.CharField(style={'input_type': 'password'}, write_only=True, required=False)
     emails = BadgeUserEmailSerializerV2(many=True, source='email_items', required=False)

--- a/apps/badgrsocialauth/providers/facebook/tests.py
+++ b/apps/badgrsocialauth/providers/facebook/tests.py
@@ -18,7 +18,7 @@ class VerifiedFacebookProviderTests(DoesNotSendVerificationEmailMixin, BadgrOAut
            "id": "630595557",
            "name": "Raymond Penners",
            "first_name": "Raymond",
-           "last_name": "Penners",
+           "last_name": "Penners, Ph.D, Extraordinary, Famous, Most Respected",
            "email": "raymond.penners@example.com",
            "link": "https://www.facebook.com/raymond.penners",
            "username": "raymond.penners",


### PR DESCRIPTION
Resolves BP-4243 where different length names were accepted for SSO signup vs user update.