### PR TITLE
report errors as required by RFC7591

### DIFF
--- a/apps/backpack/serializers_bcv1.py
+++ b/apps/backpack/serializers_bcv1.py
@@ -55,6 +55,7 @@ class BadgeConnectManifestSerializer(serializers.Serializer):
         data['@context'] = 'https://w3id.org/openbadges/badgeconnect/v1'
         return data
 
+
 class BadgeConnectStatusSerializer(serializers.Serializer):
     error = serializers.CharField(default=None)
     statusCode = serializers.IntegerField(default=200)

--- a/apps/entity/views.py
+++ b/apps/entity/views.py
@@ -6,23 +6,18 @@ from rest_framework import views, exceptions, status
 from rest_framework.response import Response
 
 from backpack.serializers_bcv1 import BadgeConnectErrorSerializer
-from entity.serializers import V2ErrorSerializer
+from entity.serializers import V2ErrorSerializer, Rfc7591ErrorSerializer
 from entity.authentication import CSRFPermissionDenied
 
 
 def exception_handler(exc, context):
-    version = context.get('kwargs', None).get('version', 'v1')
-    if version == 'v1':
-        # Use the default exception-handling logic for v1
-        if isinstance(exc, ProtectedError):
-            description, protected_objects = exc.args
-            return Response(description, status=status.HTTP_400_BAD_REQUEST)
-        return views.exception_handler(exc, context)
-    elif version == 'v2':
+    version = context.get('kwargs', {}).get('version', 'v1')
+
+    if version in ['v2', 'rfc7591']:
         description = 'miscellaneous error'
         field_errors = {}
         validation_errors = []
-        response_code = None
+
         if isinstance(exc, exceptions.ParseError):
             description = 'bad request'
             validation_errors = [exc.detail]
@@ -64,14 +59,17 @@ def exception_handler(exc, context):
         else:
             # Unrecognized exception, return 500 error
             return None
-
-        serializer = V2ErrorSerializer(instance={},
-                                       success=False,
-                                       description=description,
-                                       field_errors=field_errors,
-                                       validation_errors=validation_errors)
-
+        if version == 'v2':
+            serializer = V2ErrorSerializer(
+                instance={}, success=False, description=description,
+                field_errors=field_errors, validation_errors=validation_errors
+            )
+        else:
+            serializer = Rfc7591ErrorSerializer(
+                instance={}, field_errors=field_errors, validation_errors=validation_errors
+            )
         return Response(serializer.data, status=response_code)
+
     elif version == 'bcv1':
         # Badge Connect errors
         error = None
@@ -102,4 +100,10 @@ def exception_handler(exc, context):
                                                  status_text=status_text,
                                                  status_code=status_code)
         return Response(serializer.data, status=status_code)
-                        
+
+    else:
+        # Use the default exception-handling logic for v1
+        if isinstance(exc, ProtectedError):
+            description, protected_objects = exc.args
+            return Response(description, status=status.HTTP_400_BAD_REQUEST)
+        return views.exception_handler(exc, context)

--- a/apps/mainsite/oauth2_api.py
+++ b/apps/mainsite/oauth2_api.py
@@ -5,6 +5,7 @@ import json
 import re
 from urllib.parse import urlparse
 
+from django.core.validators import URLValidator
 from django.http import HttpResponse
 from django.utils import timezone
 from oauth2_provider.exceptions import OAuthToolkitError
@@ -147,19 +148,24 @@ class AuthorizationApiView(OAuthLibMixin, APIView):
             }, status=HTTP_400_BAD_REQUEST)
 
 
+httpsUrlValidator = URLValidator(message="Must be a valid HTTPS URI", schemes=['https'])
+
+
 class RegistrationSerializer(serializers.Serializer):
     client_name = serializers.CharField(required=True, source='name')
-    client_uri = serializers.URLField(required=True, source='applicationinfo.website_url')
-    logo_uri = serializers.URLField(required=True, source='applicationinfo.logo_uri')
-    tos_uri = serializers.URLField(required=True, source='applicationinfo.terms_uri')
-    policy_uri = serializers.URLField(required=True, source='applicationinfo.policy_uri')
+    client_uri = serializers.URLField(required=True, source='applicationinfo.website_url', validators=[httpsUrlValidator])
+    logo_uri = serializers.URLField(required=True, source='applicationinfo.logo_uri', validators=[httpsUrlValidator])
+    tos_uri = serializers.URLField(required=True, source='applicationinfo.terms_uri', validators=[httpsUrlValidator])
+    policy_uri = serializers.URLField(required=True, source='applicationinfo.policy_uri', validators=[httpsUrlValidator])
     software_id = serializers.CharField(required=True, source='applicationinfo.software_id')
     software_version = serializers.CharField(required=True, source='applicationinfo.software_version')
-    redirect_uris = serializers.ListField(child=serializers.URLField(), required=True)
+    redirect_uris = serializers.ListField(child=serializers.URLField(validators=[httpsUrlValidator]), required=True)
     token_endpoint_auth_method = serializers.CharField(required=False, default='client_secret_basic')
     grant_types = serializers.ListField(child=serializers.CharField(), required=False, default=['authorization_code'])
     response_types = serializers.ListField(child=serializers.CharField(), required=False, default=['code'])
-    scope = serializers.CharField(required=False, source='applicationinfo.allowed_scopes')
+    scope = serializers.CharField(
+        required=False, source='applicationinfo.allowed_scopes', default=' '.join(BADGE_CONNECT_SCOPES)
+    )
 
     client_id = serializers.CharField(read_only=True)
     client_secret = serializers.CharField(read_only=True)
@@ -237,10 +243,6 @@ class RegistrationSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "client_uri, logo_uri, tos_uri, policy_uri, redirect_uris do not match domain."
             )
-        if len(schemes) > 1 or schemes.pop() != 'https':
-            raise serializers.ValidationError(
-                "client_uri, logo_uri, tos_uri, policy_uri, redirect_uris URI schemes must be https"
-            )
 
         return data
 
@@ -279,7 +281,7 @@ class RegistrationSerializer(serializers.Serializer):
 class RegisterApiView(APIView):
     permission_classes = []
 
-    def post(self, request):
+    def post(self, request, **kwargs):
         serializer = RegistrationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/apps/mainsite/settings.py
+++ b/apps/mainsite/settings.py
@@ -358,7 +358,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
     'DEFAULT_VERSION': 'v1',
-    'ALLOWED_VERSIONS': ['v1','v2', 'bcv1'],
+    'ALLOWED_VERSIONS': ['v1', 'v2', 'bcv1', 'rfc7591'],
     'EXCEPTION_HANDLER': 'entity.views.exception_handler',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 100,

--- a/apps/mainsite/urls.py
+++ b/apps/mainsite/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     url(r'^o/authorize/?$', AuthorizationApiView.as_view(), name='oauth2_api_authorize'),
     url(r'^o/token/?$', TokenView.as_view(), name='oauth2_provider_token'),
     url(r'^o/code/?$', AuthCodeExchange.as_view(), name='oauth2_code_exchange'),
-    url(r'^o/register/?$', RegisterApiView.as_view(), name='oauth2_api_register'),
+    url(r'^o/register/?$', RegisterApiView.as_view(), kwargs={'version': 'rfc7591'}, name='oauth2_api_register'),
     path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 
     # Badge Connect URLs


### PR DESCRIPTION
RFC7591 requires a `{"error": "stringvalue", "error_description": "stringvalue"}` error response signature returned on client registration. When we switched to the serializer, errors started coming back in the bcv1 response envelope.
