### PR TITLE
Fix rare login issue with unverified email (BP-4240)

### DIFF
--- a/apps/badgrsocialauth/providers/tests/test_third_party.py
+++ b/apps/badgrsocialauth/providers/tests/test_third_party.py
@@ -1,44 +1,95 @@
 from allauth.socialaccount.providers.azure.provider import AzureProvider
+from urllib.parse import parse_qs, urlparse
 from allauth.socialaccount.providers.facebook.provider import FacebookProvider
 from allauth.socialaccount.providers.linkedin_oauth2.provider import LinkedInOAuth2Provider
-from allauth.tests import MockedResponse
+from allauth.tests import MockedResponse, mocked_response
+
+from django.shortcuts import reverse
+from django.test import override_settings
+
+from badgeuser.models import CachedEmailAddress
 
 from .base import BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase, DoesNotSendVerificationEmailMixin, SendsVerificationEmailMixin
 
 
-# class LinkedInOAuth2ProviderTests(DoesNotSendVerificationEmailMixin, BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase):
-#     """
-#     Leaving LinkedIn commented out for now. Tests fail and are very hard to step through.
-#     """
-#     provider_id = LinkedInOAuth2Provider.id
-#
-#     def get_mocked_response(self):
-#         response = MockedResponse(200, """{
-#             "profilePicture": {
-#                 "displayImage": "urn:li:digitalmediaAsset:12345abcdefgh-12abcd"
-#             },
-#             "id": "1234567",
-#             "lastName": {
-#                 "preferredLocale": {
-#                     "language": "en",
-#                     "country": "US"
-#                 },
-#                 "localized": {
-#                     "en_US": "Penners"
-#                 }
-#             },
-#             "firstName": {
-#                 "preferredLocale": {
-#                     "language": "en",
-#                     "country": "US"
-#                 },
-#                 "localized": {
-#                     "en_US": "Raymond"
-#                 }
-#             }
-#         }""")
-#         response.ok = True
-#         return response
+class LinkedInOAuth2ProviderTests(DoesNotSendVerificationEmailMixin, BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase):
+    provider_id = LinkedInOAuth2Provider.id
+
+    def get_mocked_response(self):
+        email_response = MockedResponse(200, """{"elements": [{"handle": "urn:li:emailAddress:319371470",
+               "handle~": {"emailAddress": "larry.exampleton@example.com"}}]}""")
+        email_response.ok = True
+
+        profile_response = MockedResponse(200, """{
+            "profilePicture": {
+                "displayImage": "urn:li:digitalmediaAsset:12345abcdefgh-12abcd"
+            },
+            "id": "3735408165",
+            "lastName": {
+                "preferredLocale": {
+                    "language": "en",
+                    "country": "US"
+                },
+                "localized": {
+                    "en_US": "Exampleton"
+                }
+            },
+            "firstName": {
+                "preferredLocale": {
+                    "language": "en",
+                    "country": "US"
+                },
+                "localized": {
+                    "en_US": "Larry"
+                }
+            }
+        }""")
+        profile_response.ok = True
+
+        return [email_response, profile_response]
+
+    def login(self, resp_mock, process='login',
+              with_refresh_token=True):
+        resp = self.client.get(reverse(self.provider.id + '_login'),
+                               dict(process=process))
+        p = urlparse(resp['location'])
+        q = parse_qs(p.query)
+        complete_url = reverse(self.provider.id + '_callback')
+        self.assertGreater(q['redirect_uri'][0]
+                           .find(complete_url), 0)
+        response_json = self \
+            .get_login_response_json(with_refresh_token=with_refresh_token)
+        with mocked_response(
+                MockedResponse(
+                    200,
+                    response_json,
+                    {'content-type': 'application/json'}),
+                *resp_mock):  # supports multiple mocks
+            resp = self.client.get(complete_url,
+                                   {'code': 'test',
+                                    'state': q['state'][0]})
+        return resp
+
+    def test_legacy_user_can_sign_in(self):
+        """
+        Users who signed up for an account at an older point in time may have had the email not automatically verified,
+        They should still be able to sign in.
+        """
+        with override_settings(SOCIALACCOUNT_PROVIDERS={self.provider.id: {'VERIFIED_EMAIL': True}}):
+            # Create account the normal way
+            self.login(self.get_mocked_response())
+            self.client.logout()
+            response = self.login(self.get_mocked_response())
+            self.assert_login_redirect(response)
+
+            # Manipulate the email to put it in the problem state
+            email = CachedEmailAddress.objects.last()
+            email.verified = False
+            email.save()
+
+            self.client.logout()
+            response = self.login(self.get_mocked_response())
+            self.assert_login_redirect(response)  # User can sign in again properly
 
 
 class AzureProviderTests(DoesNotSendVerificationEmailMixin, BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase):

--- a/apps/badgrsocialauth/providers/tests/test_third_party.py
+++ b/apps/badgrsocialauth/providers/tests/test_third_party.py
@@ -91,6 +91,9 @@ class LinkedInOAuth2ProviderTests(DoesNotSendVerificationEmailMixin, BadgrOAuth2
             response = self.login(self.get_mocked_response())
             self.assert_login_redirect(response)  # User can sign in again properly
 
+            email_again = CachedEmailAddress.objects.last()
+            self.assertTrue(email_again.verified)
+
 
 class AzureProviderTests(DoesNotSendVerificationEmailMixin, BadgrOAuth2TestsMixin, BadgrSocialAuthTestCase):
     provider_id = AzureProvider.id


### PR DESCRIPTION
If a user through a very old version of the code ended up with a SocialAccount but no verified EmailAddress, allow them to sign in via that SocialAccount if it now supports automatic email verification.