### PR TITLE
Make it possible to reset API throttling for oauth applications - BP-6218

### DIFF
--- a/apps/badgeuser/api.py
+++ b/apps/badgeuser/api.py
@@ -349,7 +349,7 @@ class BadgeUserForgotPassword(BaseUserRecoveryView):
         except DjangoValidationError as e:
             return Response(dict(password=e.messages), status=HTTP_400_BAD_REQUEST)
 
-        cache.set(backoff_cache_key(user.email, None), None)
+        cache.delete(backoff_cache_key(user.email))
 
         user.set_password(password)
         user.save()

--- a/apps/badgeuser/tests/tests.py
+++ b/apps/badgeuser/tests/tests.py
@@ -549,8 +549,8 @@ class UserEmailTests(BadgrTestCase):
             'email': self.first_user_email
         })
 
-        backoff_key = backoff_cache_key(self.first_user_email, None)
-        backoff_data = {'count': 6, 'until': timezone.now() + timezone.timedelta(seconds=60)}
+        backoff_key = backoff_cache_key(self.first_user_email)
+        backoff_data = {'127.0.0.1': {'count': 6, 'until': timezone.now() + timezone.timedelta(seconds=60)}}
         cache.set(backoff_key, backoff_data)
         self.assertEqual(cache.get(backoff_key), backoff_data)
 
@@ -828,7 +828,7 @@ class UserRecipientIdentifierTests(SetupIssuerHelper, BadgrTestCase):
         user = self.setup_user(create_email_address=False)
         v2serialized = BadgeUserSerializerV2(user).data['result'][0]
         self.assertEqual(None, v2serialized['recipient'])
-        
+
         url = 'http://example.com'
         phone = '+15413428456'
         user.userrecipientidentifier_set.create(

--- a/apps/mainsite/tests/test_api_throttle.py
+++ b/apps/mainsite/tests/test_api_throttle.py
@@ -1,7 +1,10 @@
 from django.test import override_settings
+from django.utils import timezone
+from django.utils.timezone import timedelta
 
 from mainsite.tests.base import BadgrTestCase
-from mainsite.utils import clamped_backoff_in_seconds, iterate_backoff_count
+from mainsite.utils import (_expunge_stale_backoffs, clamped_backoff_in_seconds, clear_backoff_count_for_ip,
+                            iterate_backoff_count,)
 
 SETTINGS_OVERRIDE = {
     'TOKEN_BACKOFF_MAXIMUM_SECONDS': 3600,
@@ -34,9 +37,37 @@ class BackoffTests(BadgrTestCase):
 
     @override_settings(**SETTINGS_OVERRIDE)
     def test_iterate_backoff_count(self):
-        backoff = {
-            'count': 1
-        }
+        ip1 = '1.2.3.4'
+        backoff = iterate_backoff_count(None, ip1)
 
-        new_backoff = iterate_backoff_count(backoff)
-        self.assertEqual(new_backoff['count'], 2)
+        new_backoff = iterate_backoff_count(backoff, ip1)
+        self.assertEqual(new_backoff[ip1]['count'], 2)
+
+    def test_backoff_manipulation_for_client_ip(self):
+        ip1 = '1.2.3.4'
+        ip2 = '4.5.6.7'
+        backoff = iterate_backoff_count(None, ip1)
+        self.assertEqual(backoff[ip1]['count'], 1)
+
+        backoff = iterate_backoff_count(backoff, ip1)
+        backoff = iterate_backoff_count(backoff, ip2)
+        self.assertEqual(backoff[ip1]['count'], 2)
+        self.assertEqual(backoff[ip2]['count'], 1)
+
+        backoff = clear_backoff_count_for_ip(backoff, ip1)
+        self.assertIsNone(backoff.get(ip1))
+        self.assertEqual(backoff[ip2]['count'], 1)
+
+    def test_backoff_expunging_past_entries(self):
+        ip1 = '1.2.3.4'
+        ip2 = '4.5.6.7'
+        backoff = iterate_backoff_count(None, ip1)
+        backoff = iterate_backoff_count(backoff, ip2)
+        backoff = iterate_backoff_count(backoff, ip2)
+        backoff[ip2]['until'] = timezone.now() - timedelta(minutes=1)
+
+        backoff = iterate_backoff_count(backoff, ip1)
+        self.assertIsNone(backoff.get(ip2))  # The expired "until" has been expunged
+
+
+

--- a/apps/mainsite/tests/test_api_throttle.py
+++ b/apps/mainsite/tests/test_api_throttle.py
@@ -64,10 +64,7 @@ class BackoffTests(BadgrTestCase):
         backoff = iterate_backoff_count(None, ip1)
         backoff = iterate_backoff_count(backoff, ip2)
         backoff = iterate_backoff_count(backoff, ip2)
-        backoff[ip2]['until'] = timezone.now() - timedelta(minutes=1)
+        backoff[ip2]['until'] = timezone.now() - timedelta(hours=2)
 
         backoff = iterate_backoff_count(backoff, ip1)
         self.assertIsNone(backoff.get(ip2))  # The expired "until" has been expunged
-
-
-

--- a/apps/mainsite/utils.py
+++ b/apps/mainsite/utils.py
@@ -282,6 +282,9 @@ def _expunge_stale_backoffs(backoff):
                 raise ValueError('This client_ip backoff is expired and can be removed')
         except (ValueError, TypeError, KeyError,) as e:
             del backoff[key]
+
+    if not len(backoff):
+        return
     return backoff
 
 
@@ -316,7 +319,7 @@ def throttleable(f):
         client_ip = client_ip_from_request(request)
         backoff = cache.get(backoff_cache_key(username))
 
-        if backoff is not None:
+        if backoff is not None and len(backoff):
             backoff_for_ip = backoff.get(client_ip, dict())
 
             if max_backoff != 0 and not _request_authenticated_with_admin_scope(request):

--- a/apps/mainsite/utils.py
+++ b/apps/mainsite/utils.py
@@ -278,7 +278,8 @@ def _expunge_stale_backoffs(backoff):
     backoff_keys = list(backoff.keys())
     for key in backoff_keys:
         try:
-            if backoff[key]['until'] < timezone.now():
+            an_hour_ago = timezone.now() - timezone.timedelta(hours=1)
+            if backoff[key]['until'] < an_hour_ago:
                 raise ValueError('This client_ip backoff is expired and can be removed')
         except (ValueError, TypeError, KeyError,) as e:
             del backoff[key]

--- a/apps/mainsite/utils.py
+++ b/apps/mainsite/utils.py
@@ -50,6 +50,7 @@ slugify_function_path = \
 
 slugify = get_callable(slugify_function_path)
 
+
 def installed_apps_list():
     installed_apps = []
     for app in ('issuer', 'composition', 'badgebook'):
@@ -70,9 +71,8 @@ def client_ip_from_request(request):
     return ip
 
 
-def backoff_cache_key(username=None, client_ip=None):
-    client_descriptor = username if username else client_ip
-    return "failed_token_backoff_{}".format(client_descriptor)
+def backoff_cache_key(client_descriptor=""):
+    return "failed_auth_backoff_{}".format(client_descriptor)
 
 
 class OriginSettingsObject(object):
@@ -274,12 +274,37 @@ def clamped_backoff_in_seconds(backoff_count):
     )
 
 
-def iterate_backoff_count(backoff):
-    if backoff is None:
-        backoff = {'count': 0}
-    backoff['count'] += 1
-    backoff['until'] = timezone.now() + datetime.timedelta(seconds=clamped_backoff_in_seconds(backoff['count']))
+def _expunge_stale_backoffs(backoff):
+    backoff_keys = list(backoff.keys())
+    for key in backoff_keys:
+        try:
+            if backoff[key]['until'] < timezone.now():
+                raise ValueError('This client_ip backoff is expired and can be removed')
+        except (ValueError, TypeError, KeyError,) as e:
+            del backoff[key]
     return backoff
+
+
+def iterate_backoff_count(backoff, client_ip):
+    if backoff is None:
+        backoff = dict()
+    if backoff.get(client_ip) is None:
+        backoff[client_ip] = {'count': 0}
+    backoff[client_ip]['count'] += 1
+    backoff[client_ip]['until'] = timezone.now() + datetime.timedelta(
+        seconds=clamped_backoff_in_seconds(backoff[client_ip]['count'])
+    )
+
+    return _expunge_stale_backoffs(backoff)
+
+
+def clear_backoff_count_for_ip(backoff, client_ip):
+    if backoff is None:
+        return
+
+    if backoff.get(client_ip) is not None:
+        del backoff[client_ip]
+    return _expunge_stale_backoffs(backoff)
 
 
 def throttleable(f):
@@ -287,38 +312,41 @@ def throttleable(f):
     def wrapper(*args, **kw):
         max_backoff = getattr(settings, 'TOKEN_BACKOFF_MAXIMUM_SECONDS', 3600)  # max is 1 hour. Set to 0 to disable.
         request = args[0].request
-        username = request.POST.get('username')
+        username = request.POST.get('username', request.POST.get('client_id', None))
         client_ip = client_ip_from_request(request)
-        backoff = cache.get(backoff_cache_key(username, client_ip))
+        backoff = cache.get(backoff_cache_key(username))
 
-        if backoff is not None and max_backoff != 0 and not _request_authenticated_with_admin_scope(request):
-            backoff_until = backoff.get('until', None)
-            if backoff_until > timezone.now():
-                # Don't increase the backoff count, just return 429.
-                return HttpResponse(json.dumps({
-                    "error_description": "Too many login attempts. Please wait and try again.",
-                    "error": "login attempts throttled",
-                    "expires": clamped_backoff_in_seconds(backoff.get('count')),
-                }), status=HTTP_429_TOO_MANY_REQUESTS)
+        if backoff is not None:
+            backoff_for_ip = backoff.get(client_ip, dict())
+
+            if max_backoff != 0 and not _request_authenticated_with_admin_scope(request):
+                backoff_until = backoff_for_ip.get('until', None)
+                if backoff_until and backoff_until > timezone.now():
+                    # Don't increase the backoff count, just return 429.
+                    return HttpResponse(json.dumps({
+                        "error_description": "Too many login attempts. Please wait and try again.",
+                        "error": "login attempts throttled",
+                        "expires": clamped_backoff_in_seconds(backoff_for_ip.get('count')),
+                    }), status=HTTP_429_TOO_MANY_REQUESTS)
 
         try:
             result = f(*args, **kw)  # execute the decorated function
 
             if 200 <= result.status_code < 300:
                 cache.set(
-                    backoff_cache_key(username, client_ip),
-                    None
+                    backoff_cache_key(username),
+                    clear_backoff_count_for_ip(backoff, client_ip)
                 )  # clear any existing backoff
             else:
                 cache.set(
-                    backoff_cache_key(username, client_ip),
-                    iterate_backoff_count(backoff),
+                    backoff_cache_key(username),
+                    iterate_backoff_count(backoff, client_ip),
                     timeout=max_backoff
                 )
         except Exception as e:
             cache.set(
-                backoff_cache_key(username, client_ip),
-                iterate_backoff_count(backoff),
+                backoff_cache_key(username),
+                iterate_backoff_count(backoff, client_ip),
                 timeout=max_backoff
             )
             raise e


### PR DESCRIPTION
Make it possible to reset API throttling for oauth applications as well as user passwords. 

Now it is possible to view login_backoff throttling information from these locations:
* `/staff/oauth2_provider/application/:id/change/` for a OAuth2 Application
* `/staff/badgeuser/badgeuser/:id/change/` for a User

You'll be able to see the IP addresses that have been throttled for each entity type. In each location, a user may use an action "Clear login backoffs" to reset the counter for the client.