### PR TITLE
Bugfix/bp 6169 Validate criteria in posted badge.

### DIFF
--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -239,13 +239,9 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
 
     def validate(self, data):
         if 'criteria' in data:
-            if 'criteria_url' in data and 'criteria_text' in data:
+            if 'criteria_url' in data or 'criteria_text' in data:
                 raise serializers.ValidationError(
-                    "The criteria field is mutually-exclusive with the criteria_url and criteria_text fields."
-                )
-            if 'criteria_url' not in data  and 'criteria_text' not in data:
-                raise serializers.ValidationError(
-                    "A criteria_url or criteria_test is required."
+                    "The criteria field is mutually-exclusive with the criteria_url and criteria_text fields------"
                 )
 
             if utils.is_probable_url(data.get('criteria')):

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -239,9 +239,13 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
 
     def validate(self, data):
         if 'criteria' in data:
-            if 'criteria_url' in data or 'criteria_text' in data:
+            if 'criteria_url' in data and 'criteria_text' in data:
                 raise serializers.ValidationError(
-                    "The criteria field is mutually-exclusive with the criteria_url and criteria_text fields"
+                    "The criteria field is mutually-exclusive with the criteria_url and criteria_text fields."
+                )
+            if 'criteria_url' not in data  and 'criteria_text' not in data:
+                raise serializers.ValidationError(
+                    "A criteria_url or criteria_test is required."
                 )
 
             if utils.is_probable_url(data.get('criteria')):

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -241,7 +241,7 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
         if 'criteria' in data:
             if 'criteria_url' in data or 'criteria_text' in data:
                 raise serializers.ValidationError(
-                    "The criteria field is mutually-exclusive with the criteria_url and criteria_text fields------"
+                    "The criteria field is mutually-exclusive with the criteria_url and criteria_text fields"
                 )
 
             if utils.is_probable_url(data.get('criteria')):

--- a/apps/issuer/serializers_v2.py
+++ b/apps/issuer/serializers_v2.py
@@ -383,6 +383,8 @@ class BadgeClassSerializerV2(DetailSerializerV2, OriginalJsonSerializerMixin):
         else:
             # issuer is required on create
             raise serializers.ValidationError({"issuer": "This field is required"})
+        if 'criteria_url' not in validated_data  and 'criteria_text' not in validated_data:
+            raise serializers.ValidationError("A criteria_url or criteria_test is required.")
 
         if not IsEditor().has_object_permission(self.context.get('request'), None, validated_data['issuer']):
             raise serializers.ValidationError({"issuer": "You do not have permission to edit badges on this issuer."})

--- a/apps/issuer/tests/test_badgeclass.py
+++ b/apps/issuer/tests/test_badgeclass.py
@@ -1241,7 +1241,7 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             format="json"
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data["validationErrors"][0], "One or both of the criteria_text and criteria_url fields must be provided")
+        self.assertEqual(response.data["non_field_errors"][0], "One or both of the criteria_text and criteria_url fields must be provided")
 
 class BadgeClassesChangedApplicationTests(SetupIssuerHelper, BadgrTestCase):
     def test_application_can_get_changed_badgeclasses(self):

--- a/apps/issuer/tests/test_badgeclass.py
+++ b/apps/issuer/tests/test_badgeclass.py
@@ -1184,7 +1184,7 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
         response = self.client.get('/public/assertions/{}.json?expand=badge&expand=badge.issuer'.format(assertion_slug))
         self.assertEqual(response.data['badge']['issuer']['name'], 'Issuer 1 updated')
 
-    def can_create_badgeclass_with_serverAdmin_token(self):
+    def test_can_create_badgeclass_with_serverAdmin_token(self):
         issuer_owner = self.setup_user(authenticate=False)
         admin_user = self.setup_user(authenticate=True, verified=True, token_scope='rw:serverAdmin')
         test_issuer = self.setup_issuer(owner=issuer_owner)
@@ -1193,7 +1193,7 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             'name': 'Test Badge',
             'description': "A testing badge",
             'image': self.get_test_image_base64(),
-            'criteria': 'http://wikipedia.org/Awesome',
+            'criteriaUrl': 'http://wikipedia.org/Awesome',
             'issuer': test_issuer.entity_id,
         }
 


### PR DESCRIPTION
This PR adds a check in the v2 serializer to return an error if neither criteria field is supplied.
Tests that passed due to the lack of this check were updated.
Tests were added to prevent regression for both APIs.