### PR TITLE
BP-6347 : protect bage class edits from stripping criteria

### DIFF
--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -218,18 +218,18 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
             instance.description = strip_tags(new_description)
 
         # Assure both criteria_url and criteria_text will not be empty
-        if ('criteria_url' in validated_data or 'criteria_text' in validated_data):
+        if 'criteria_url' in validated_data or 'criteria_text' in validated_data:
             end_criteria_url = validated_data['criteria_url'] if  'criteria_url' in validated_data \
                 else instance.criteria_url
-
             end_criteria_text = validated_data['criteria_text'] if 'criteria_text' in validated_data \
                 else instance.criteria_text
 
-            if (not end_criteria_url.strip() if end_criteria_url is not None else True) \
-                    and (not end_criteria_text.strip() if end_criteria_text is not None else True):
+            if ((end_criteria_url is None or not end_criteria_url.strip())
+                    and (end_criteria_text is None or not end_criteria_text.strip())):
                 raise serializers.ValidationError(
                     'Changes cannot be made that would leave both criteria_url and criteria_text blank.'
                 )
+
 
             else:
                 instance.criteria_text = end_criteria_text

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -217,10 +217,23 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
         if new_description:
             instance.description = strip_tags(new_description)
 
-        if 'criteria_text' in validated_data:
-            instance.criteria_text = validated_data.get('criteria_text')
-        if 'criteria_url' in validated_data:
-            instance.criteria_url = validated_data.get('criteria_url')
+        # Assure both criteria_url and criteria_text will not be empty
+        if ('criteria_url' in validated_data or 'criteria_text' in validated_data):
+            end_criteria_url = validated_data['criteria_url'] if  'criteria_url' in validated_data \
+                else instance.criteria_url
+
+            end_criteria_text = validated_data['criteria_text'] if 'criteria_text' in validated_data \
+                else instance.criteria_text
+
+            if (not end_criteria_url.strip() if end_criteria_url is not None else True) \
+                    and (not end_criteria_text.strip() if end_criteria_text is not None else True):
+                raise serializers.ValidationError(
+                    'Changes cannot be made that would leave both criteria_url and criteria_text blank.'
+                )
+
+            else:
+                instance.criteria_text = end_criteria_text
+                instance.criteria_url = end_criteria_url
 
         if 'image' in validated_data:
             instance.image = validated_data.get('image')
@@ -228,7 +241,6 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
 
         instance.alignment_items = validated_data.get('alignment_items')
         instance.tag_items = validated_data.get('tag_items')
-
 
         instance.expires_amount = validated_data.get('expires_amount', None)
         instance.expires_duration = validated_data.get('expires_duration', None)
@@ -252,13 +264,6 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
                 )
             else:
                 data['criteria_text'] = data.pop('criteria')
-
-        else:
-            if data.get('criteria_text', None) is None and data.get('criteria_url', None) is None:
-                raise serializers.ValidationError(
-                    "One or both of the criteria_text and criteria_url fields must be provided"
-                )
-
         return data
 
     def create(self, validated_data, **kwargs):
@@ -268,6 +273,11 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
 
         if 'issuer' in self.context:
             validated_data['issuer'] = self.context.get('issuer')
+
+        if validated_data.get('criteria_text', None) is None and validated_data.get('criteria_url', None) is None:
+            raise serializers.ValidationError(
+                "One or both of the criteria_text and criteria_url fields must be provided"
+            )
 
         new_badgeclass = BadgeClass.objects.create(**validated_data)
         return new_badgeclass

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -229,8 +229,6 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, serializers.Serializer
                 raise serializers.ValidationError(
                     'Changes cannot be made that would leave both criteria_url and criteria_text blank.'
                 )
-
-
             else:
                 instance.criteria_text = end_criteria_text
                 instance.criteria_url = end_criteria_url

--- a/apps/issuer/serializers_v2.py
+++ b/apps/issuer/serializers_v2.py
@@ -365,6 +365,17 @@ class BadgeClassSerializerV2(DetailSerializerV2, OriginalJsonSerializerMixin):
         if 'image' in validated_data:
             self.context['save_kwargs'] = dict(force_resize=True)
 
+        # Verify that criteria won't be empty
+        if ('criteria_url' in validated_data or 'criteria_text' in validated_data):
+            end_criteria_url = validated_data['criteria_url'] if  'criteria_url' in validated_data \
+                else instance.criteria_url
+            end_criteria_text = validated_data['criteria_text'] if 'criteria_text' in validated_data \
+                else instance.criteria_text
+            if (not end_criteria_url.strip() if end_criteria_url is not None else True) \
+                    and (not end_criteria_text.strip() if end_criteria_text is not None else True):
+                raise serializers.ValidationError('Changes cannot be made that would leave both criteria_url and '
+                                                  'criteria_text blank.')
+
         if not IsEditor().has_object_permission(self.context.get('request'), None, instance.issuer):
             raise serializers.ValidationError(
                 {"issuer": "You do not have permission to edit badges on this issuer."})

--- a/apps/issuer/serializers_v2.py
+++ b/apps/issuer/serializers_v2.py
@@ -366,13 +366,14 @@ class BadgeClassSerializerV2(DetailSerializerV2, OriginalJsonSerializerMixin):
             self.context['save_kwargs'] = dict(force_resize=True)
 
         # Verify that criteria won't be empty
-        if ('criteria_url' in validated_data or 'criteria_text' in validated_data):
-            end_criteria_url = validated_data['criteria_url'] if  'criteria_url' in validated_data \
+        if 'criteria_url' in validated_data or 'criteria_text' in validated_data:
+            end_criteria_url = validated_data['criteria_url'] if 'criteria_url' in validated_data \
                 else instance.criteria_url
             end_criteria_text = validated_data['criteria_text'] if 'criteria_text' in validated_data \
                 else instance.criteria_text
-            if (not end_criteria_url.strip() if end_criteria_url is not None else True) \
-                    and (not end_criteria_text.strip() if end_criteria_text is not None else True):
+
+            if ((end_criteria_url is None or not end_criteria_url.strip())
+                    and (end_criteria_text is None or not end_criteria_text.strip())):
                 raise serializers.ValidationError('Changes cannot be made that would leave both criteria_url and '
                                                   'criteria_text blank.')
 

--- a/apps/issuer/tests/test_badgeclass.py
+++ b/apps/issuer/tests/test_badgeclass.py
@@ -55,9 +55,9 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             test_issuer = self.setup_issuer(owner=test_user)
             self.issuer = test_issuer
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                                        data=example_badgeclass_props,
-                                        format="json"
-                                        )
+                data=example_badgeclass_props,
+                format="json"
+            )
             self.assertEqual(response.status_code, 201)
             self.assertIn('slug', response.data)
             new_badgeclass_slug = response.data.get('slug')
@@ -115,9 +115,9 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             IssuerStaff.objects.create(issuer=test_issuer, user=test_user, role=IssuerStaff.ROLE_STAFF)
             self.issuer = test_issuer
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                                        data=example_badgeclass_props,
-                                        format="json"
-                                        )
+                data=example_badgeclass_props,
+                format="json"
+            )
             self.assertEqual(response.status_code, 404)
 
     def test_v2_post_put_badgeclasses_permissions(self):
@@ -416,8 +416,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             test_user = self.setup_user(authenticate=True)
             test_issuer = self.setup_issuer(owner=test_user)
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                                        badgeclass_props
-                                        )
+                badgeclass_props
+            )
             self.assertEqual(response.status_code, 400)
 
     def test_cannot_create_badgeclass_if_unauthenticated(self):
@@ -521,8 +521,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             # should not create badge that has images in markdown
             badgeclass_props['criteria'] = 'This is invalid ![foo](image-url) markdown'
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                                        badgeclass_props
-                                        )
+                badgeclass_props
+            )
             self.assertEqual(response.status_code, 400)
 
     def test_can_create_badgeclass_with_valid_markdown(self):
@@ -540,8 +540,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             # valid markdown should be saved but html tags stripped
             badgeclass_props['criteria'] = 'This is *valid* markdown <p>mixed with raw</p> <script>document.write("and abusive html")</script>'
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                                        badgeclass_props
-                                        )
+                badgeclass_props
+            )
             self.assertEqual(response.status_code, 201)
             self.assertIsNotNone(response.data)
             new_badgeclass = response.data
@@ -651,8 +651,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             }
 
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                                        example_badgeclass_props
-                                        )
+                example_badgeclass_props
+            )
             self.assertEqual(response.status_code, 201)
 
         new_badgelist = self.client.get('/v1/issuer/all-badges')
@@ -763,8 +763,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             }
 
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                                        dict(badgeclass_props, image=badge_image),
-                                        )
+                dict(badgeclass_props, image=badge_image),
+            )
             self.assertEqual(response.status_code, 201)
             self.assertIn('slug', response.data)
             badgeclass_slug = response.data.get('slug')
@@ -795,14 +795,14 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
 
         with open(self.get_testfiles_path('300x300.png'), 'rb') as badge_image:
             post_response = self.client.post('/v1/issuer/issuers/{issuer}/badges'.format(issuer=test_issuer.entity_id),
-                                             dict(badgeclass_props, image=badge_image),
-                                             )
+                dict(badgeclass_props, image=badge_image),
+            )
             self.assertEqual(post_response.status_code, 201)
             slug = post_response.data.get('slug')
 
         put_response = self.client.put('/v1/issuer/issuers/{issuer}/badges/{badge}'.format(issuer=test_issuer.entity_id, badge=slug),
             dict(badgeclass_props, image='http://example.com/example.png')
-            )
+        )
         self.assertEqual(put_response.status_code, 200)
 
         new_badgeclass = BadgeClass.objects.get(entity_id=slug)
@@ -824,8 +824,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
 
         with open(self.get_testfiles_path('300x300.png'), 'rb') as badge_image:
             post_response = self.client.post('/v1/issuer/issuers/{issuer}/badges'.format(issuer=test_issuer.entity_id),
-                                             dict(badgeclass_props, image=badge_image),
-                                             )
+                dict(badgeclass_props, image=badge_image),
+            )
             self.assertEqual(post_response.status_code, 201)
             slug = post_response.data.get('slug')
 
@@ -833,7 +833,7 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             put_response = self.client.put('/v1/issuer/issuers/{issuer}/badges/{badge}'.format(issuer=test_issuer.entity_id, badge=slug),
                 dict(badgeclass_props, image=new_badge_image),
                 format='multipart'
-                )
+            )
             self.assertEqual(put_response.status_code, 200)
 
             new_badgeclass = BadgeClass.objects.get(entity_id=slug)
@@ -856,9 +856,9 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             }
 
             post_response = self.client.post('/v1/issuer/issuers/{issuer}/badges'.format(issuer=test_issuer.entity_id),
-                                             example_badgeclass_props,
-                                             format='multipart'
-                                             )
+                example_badgeclass_props,
+                format='multipart'
+            )
         self.assertEqual(post_response.status_code, 201)
 
         self.assertIn('slug', post_response.data)
@@ -867,7 +867,7 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
         self.assertEqual(get_response.status_code, 200)
 
         put_response = self.client.put('/v1/issuer/issuers/{issuer}/badges/{badge}'.format(issuer=test_issuer.entity_id, badge=slug),
-            get_response.data, format='json')
+                                       get_response.data, format='json')
         self.assertEqual(put_response.status_code, 200)
 
         self.assertEqual(get_response.data, put_response.data)

--- a/apps/issuer/tests/test_badgeclass.py
+++ b/apps/issuer/tests/test_badgeclass.py
@@ -55,9 +55,9 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             test_issuer = self.setup_issuer(owner=test_user)
             self.issuer = test_issuer
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                data=example_badgeclass_props,
-                format="json"
-            )
+                                        data=example_badgeclass_props,
+                                        format="json"
+                                        )
             self.assertEqual(response.status_code, 201)
             self.assertIn('slug', response.data)
             new_badgeclass_slug = response.data.get('slug')
@@ -115,9 +115,9 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             IssuerStaff.objects.create(issuer=test_issuer, user=test_user, role=IssuerStaff.ROLE_STAFF)
             self.issuer = test_issuer
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                data=example_badgeclass_props,
-                format="json"
-            )
+                                        data=example_badgeclass_props,
+                                        format="json"
+                                        )
             self.assertEqual(response.status_code, 404)
 
     def test_v2_post_put_badgeclasses_permissions(self):
@@ -416,8 +416,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             test_user = self.setup_user(authenticate=True)
             test_issuer = self.setup_issuer(owner=test_user)
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                badgeclass_props
-            )
+                                        badgeclass_props
+                                        )
             self.assertEqual(response.status_code, 400)
 
     def test_cannot_create_badgeclass_if_unauthenticated(self):
@@ -521,8 +521,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             # should not create badge that has images in markdown
             badgeclass_props['criteria'] = 'This is invalid ![foo](image-url) markdown'
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                badgeclass_props
-            )
+                                        badgeclass_props
+                                        )
             self.assertEqual(response.status_code, 400)
 
     def test_can_create_badgeclass_with_valid_markdown(self):
@@ -540,8 +540,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             # valid markdown should be saved but html tags stripped
             badgeclass_props['criteria'] = 'This is *valid* markdown <p>mixed with raw</p> <script>document.write("and abusive html")</script>'
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                badgeclass_props
-            )
+                                        badgeclass_props
+                                        )
             self.assertEqual(response.status_code, 201)
             self.assertIsNotNone(response.data)
             new_badgeclass = response.data
@@ -651,8 +651,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             }
 
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                example_badgeclass_props
-            )
+                                        example_badgeclass_props
+                                        )
             self.assertEqual(response.status_code, 201)
 
         new_badgelist = self.client.get('/v1/issuer/all-badges')
@@ -763,8 +763,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             }
 
             response = self.client.post('/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
-                dict(badgeclass_props, image=badge_image),
-            )
+                                        dict(badgeclass_props, image=badge_image),
+                                        )
             self.assertEqual(response.status_code, 201)
             self.assertIn('slug', response.data)
             badgeclass_slug = response.data.get('slug')
@@ -795,14 +795,14 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
 
         with open(self.get_testfiles_path('300x300.png'), 'rb') as badge_image:
             post_response = self.client.post('/v1/issuer/issuers/{issuer}/badges'.format(issuer=test_issuer.entity_id),
-                dict(badgeclass_props, image=badge_image),
-            )
+                                             dict(badgeclass_props, image=badge_image),
+                                             )
             self.assertEqual(post_response.status_code, 201)
             slug = post_response.data.get('slug')
 
         put_response = self.client.put('/v1/issuer/issuers/{issuer}/badges/{badge}'.format(issuer=test_issuer.entity_id, badge=slug),
             dict(badgeclass_props, image='http://example.com/example.png')
-        )
+            )
         self.assertEqual(put_response.status_code, 200)
 
         new_badgeclass = BadgeClass.objects.get(entity_id=slug)
@@ -824,8 +824,8 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
 
         with open(self.get_testfiles_path('300x300.png'), 'rb') as badge_image:
             post_response = self.client.post('/v1/issuer/issuers/{issuer}/badges'.format(issuer=test_issuer.entity_id),
-                dict(badgeclass_props, image=badge_image),
-            )
+                                             dict(badgeclass_props, image=badge_image),
+                                             )
             self.assertEqual(post_response.status_code, 201)
             slug = post_response.data.get('slug')
 
@@ -833,7 +833,7 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             put_response = self.client.put('/v1/issuer/issuers/{issuer}/badges/{badge}'.format(issuer=test_issuer.entity_id, badge=slug),
                 dict(badgeclass_props, image=new_badge_image),
                 format='multipart'
-            )
+                )
             self.assertEqual(put_response.status_code, 200)
 
             new_badgeclass = BadgeClass.objects.get(entity_id=slug)
@@ -856,9 +856,9 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             }
 
             post_response = self.client.post('/v1/issuer/issuers/{issuer}/badges'.format(issuer=test_issuer.entity_id),
-                example_badgeclass_props,
-                format='multipart'
-            )
+                                             example_badgeclass_props,
+                                             format='multipart'
+                                             )
         self.assertEqual(post_response.status_code, 201)
 
         self.assertIn('slug', post_response.data)
@@ -867,7 +867,7 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
         self.assertEqual(get_response.status_code, 200)
 
         put_response = self.client.put('/v1/issuer/issuers/{issuer}/badges/{badge}'.format(issuer=test_issuer.entity_id, badge=slug),
-                                       get_response.data, format='json')
+            get_response.data, format='json')
         self.assertEqual(put_response.status_code, 200)
 
         self.assertEqual(get_response.data, put_response.data)
@@ -1241,7 +1241,143 @@ class BadgeClassTests(SetupIssuerHelper, BadgrTestCase):
             format="json"
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data["non_field_errors"][0], "One or both of the criteria_text and criteria_url fields must be provided")
+        self.assertEqual(response.data[0],
+                         "One or both of the criteria_text and criteria_url fields must be provided")
+
+    def test_update_badgeclass_with_null_criteria_v2_bad_request(self):
+        test_user = self.setup_user(authenticate=True)
+        test_issuer = self.setup_issuer(owner=test_user)
+        self.issuer = test_issuer
+
+        badgeclass_data = {
+            'name': 'Test Badge',
+            'description': "A testing badge",
+            'image': self.get_test_image_base64(),
+            'criteriaUrl': 'http://wikipedia.org/Awesome',
+            'issuer': test_issuer.entity_id,
+        }
+
+        # Create Badge without narrative
+        response = self.client.post('/v2/badgeclasses', data=badgeclass_data, format="json")
+        modifyData = response.data['result'][0]
+        modifyData["criteriaUrl"] = None
+
+        # Try to remove url
+        response1 = self.client.put("/v2/badgeclasses/{badge}".format(badge=modifyData.get('entityId')),
+                                    data=modifyData,
+                                    format="json")
+        self.assertEqual(response1.status_code, 400)
+        self.assertEqual(response1.data['validationErrors'][0],
+                         'Changes cannot be made that would leave both criteria_url and criteria_text blank.')
+
+        # Verify that setting one will allow removing the other.
+        modifyData['criteriaNarrative'] = 'Description'
+        response2 = self.client.put("/v2/badgeclasses/{badge}".format(badge=modifyData.get('entityId')),
+                                    data=modifyData,
+                                    format="json")
+        self.assertEqual(response2.status_code, 200)
+
+        # Try to remove narrative
+        modifyData['criteriaNarrative'] = ''
+        response3 = self.client.put("/v2/badgeclasses/{badge}".format(badge=modifyData.get('entityId')),
+                                    data=modifyData,
+                                    format="json")
+        self.assertEqual(response3.status_code, 400)
+        self.assertEqual(response3.data["fieldErrors"]['criteriaNarrative'][0], 'This field may not be blank.')
+
+        # Verify that not sending either won't prevent the changes sent
+        del modifyData["criteriaNarrative"]
+        del modifyData["criteriaUrl"]
+
+        response4 = self.client.put("/v2/badgeclasses/{badge}".format(badge=modifyData.get('entityId')),
+                                    data=modifyData,
+                                    format="json")
+
+        self.assertEqual(response4.status_code, 200)
+        returnedBadge4 = response4.data["result"][0]
+        self.assertEqual(returnedBadge4.get("criteriaNarrative", None), 'Description')
+        self.assertEqual(returnedBadge4.get("criteriaUrl", None), None)
+
+    def test_update_badgeclass_with_null_criteria_v1_bad_request(self):
+        image_path = self.get_test_image_path()
+        test_user = self.setup_user(authenticate=True)
+        test_issuer = self.setup_issuer(owner=test_user)
+        self.issuer = test_issuer
+        with open(image_path, 'rb') as badge_image:
+            example_badgeclass_props = {
+                'name': 'Badge of Awesome',
+                'description': "An awesome badge only awarded to awesome people or non-existent test entities",
+                'image': self._base64_data_uri_encode(badge_image, 'image/png'),
+                'criteria': 'http://wikipedia.org/Awesome',
+            }
+
+        # Create Badge without narrative
+        response = self.client.post(
+            '/v1/issuer/issuers/{slug}/badges'.format(slug=test_issuer.entity_id),
+            data=example_badgeclass_props,
+            format="json")
+
+        modifyData = response.data
+        modifyData["criteria_url"] = None
+
+        response1 = self.client.put(
+                '/v1/issuer/issuers/{issuer}/badges/{badge}'.format(
+                    issuer=test_issuer.entity_id,
+                    badge=modifyData['slug']
+                ),
+                data=modifyData,
+                format="json",
+        )
+
+        self.assertEqual(response1.status_code, 400)
+        self.assertEqual(response1.data[0],
+                         'Changes cannot be made that would leave both criteria_url and criteria_text blank.')
+
+        # Verify that setting one will allow removing the other.
+        modifyData['criteria_text'] = 'Description'
+        response2 = self.client.put(
+            '/v1/issuer/issuers/{issuer}/badges/{badge}'.format(
+                issuer=test_issuer.entity_id,
+                badge=modifyData['slug']
+            ),
+            data=modifyData,
+            format="json",
+        )
+
+        self.assertEqual(response2.status_code, 200)
+
+        # Try to remove narrative
+        modifyData['criteria_text'] = ''
+        response3 = self.client.put(
+            '/v1/issuer/issuers/{issuer}/badges/{badge}'.format(
+                issuer=test_issuer.entity_id,
+                badge=modifyData['slug']
+            ),
+            data=modifyData,
+            format="json",
+        )
+
+        self.assertEqual(response3.status_code, 400)
+        self.assertEqual(response3.data[0],
+                         'Changes cannot be made that would leave both criteria_url and criteria_text blank.')
+
+        # Verify that not sending either won't prevent the changes sent
+        del modifyData["criteria_text"]
+        del modifyData["criteria_url"]
+
+        response4 = self.client.put(
+            '/v1/issuer/issuers/{issuer}/badges/{badge}'.format(
+                issuer=test_issuer.entity_id,
+                badge=modifyData['slug']
+            ),
+            data=modifyData,
+            format="json",
+        )
+
+        self.assertEqual(response4.status_code, 200)
+        self.assertEqual(response4.data.get("criteria_text", None), 'Description')
+        self.assertEqual(response4.data.get("criteria_url", None), None)
+
 
 class BadgeClassesChangedApplicationTests(SetupIssuerHelper, BadgrTestCase):
     def test_application_can_get_changed_badgeclasses(self):


### PR DESCRIPTION
BP-6347:

* Added validation in the updating function to disallow stripping both criteria fields
* Moved criteria blank checks to appropriate methods, left individual field validation in serializer
* Wrote tests for both v1 and v2
* Fixed test to check v1 void criteria creation to accommodate the new error