### PR TITLE
Remove feature for automatic reporting to badgerank on first award

### DIFF
--- a/apps/issuer/api.py
+++ b/apps/issuer/api.py
@@ -245,13 +245,7 @@ class BadgeClassDetail(BaseEntityDetailView):
         tags=['BadgeClasses'],
     )
     def put(self, request, **kwargs):
-        response = super(BadgeClassDetail, self).put(request, **kwargs)
-        if response.status_code == 200 and getattr(settings, 'BADGERANK_NOTIFY_ON_FIRST_ASSERTION', True):
-            badgeclass = self.get_object(request, **kwargs)
-            if badgeclass.has_nonrevoked_assertions():
-                from issuer.tasks import notify_badgerank_of_badgeclass
-                notify_badgerank_of_badgeclass.delay(badgeclass_pk=badgeclass.pk)
-        return response
+        return super(BadgeClassDetail, self).put(request, **kwargs)
 
 
 class BatchAssertionsIssue(VersionedObjectMixin, BaseEntityView):

--- a/apps/issuer/managers.py
+++ b/apps/issuer/managers.py
@@ -321,13 +321,6 @@ class BadgeInstanceManager(BaseOpenBadgeObjectManager):
             **kwargs
         )
 
-        notify_badgerank = (
-           (
-                not getattr(settings, 'BADGERANK_NOTIFY_ON_BADGECLASS_CREATE', True) and
-                getattr(settings, 'BADGERANK_NOTIFY_ON_FIRST_ASSERTION', True)
-           ) and not badgeclass.has_nonrevoked_assertions()
-        )
-
         with transaction.atomic():
             new_instance.save()
 
@@ -355,9 +348,5 @@ class BadgeInstanceManager(BaseOpenBadgeObjectManager):
 
         if notify:
             new_instance.notify_earner(badgr_app=badgr_app)
-
-        if notify_badgerank:
-            from issuer.tasks import notify_badgerank_of_badgeclass
-            notify_badgerank_of_badgeclass.delay(badgeclass_pk=badgeclass.pk)
 
         return new_instance


### PR DESCRIPTION
This feature caused some undesirable extra database queries on each award. Optimize the award call by removing this.